### PR TITLE
[codex] #22 Quest MVP용 파라메트릭 Streamlit 앱 템플릿 적용

### DIFF
--- a/agents/implementation/prototype_builder_agent.py
+++ b/agents/implementation/prototype_builder_agent.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 from clients.llm import LLMClient
-from orchestrator.app_source import build_streamlit_app_source
+from loaders import load_planning_package
+from orchestrator.app_source import build_content_filename, build_streamlit_app_source
 from schemas.implementation.common import GeneratedFile
 from schemas.implementation.prototype_builder import (
     PrototypeBuilderInput,
@@ -22,30 +25,106 @@ def run_prototype_builder_agent(
     _ = load_prompt_text
     _ = dump_model
 
+    spec = input_model.implementation_spec
+    service_name = spec.service_name or input_model.spec_intake_output.service_summary.split(" ")[0]
+    content_filename = build_content_filename(service_name)
+    app_source = _build_app_source(input_model)
+    runtime_notes = [
+        f"app.py는 outputs/{content_filename}을 읽는다.",
+        "streamlit run app.py로 실행한다.",
+    ]
+    integration_notes = [
+        f"{content_filename}이 outputs/ 아래에 존재해야 한다.",
+    ]
+    if _is_planning_package_dir(Path(spec.source_path)):
+        runtime_notes.append("생성된 app.py는 Quest 세션 기반 화면(S0~S5)으로 동작한다.")
+        integration_notes.append(
+            "score_rules, grade_levels, grade_thresholds는 app.py 생성 시 상수로 삽입된다."
+        )
+    else:
+        runtime_notes.append("planning package 입력이 아니면 generic viewer fallback을 사용한다.")
+        integration_notes.append("generic viewer는 전체 콘텐츠를 한 번에 보여준다.")
+
     return PrototypeBuilderOutput(
         agent=make_label(
             "Prototype Builder Agent",
             "MVP 서비스 코드 생성 Agent",
         ),
-        service_name=input_model.spec_intake_output.service_summary.split(" ")[0]
-        or "교육 서비스 MVP",
+        service_name=service_name or "교육 서비스 MVP",
         app_entrypoint="app.py",
         generated_files=[
             GeneratedFile(
                 path="app.py",
-                description="Self-contained Streamlit MVP app generated from quiz contents.",
-                content=build_streamlit_app_source(
-                    "교육 서비스 MVP",
-                    "quiz_contents.json",
-                ),
+                description="Self-contained Streamlit MVP app generated from service contents.",
+                content=app_source,
             )
         ],
-        runtime_notes=[
-            "app.py는 outputs/서비스별 콘텐츠 파일을 읽는다.",
-            "streamlit run app.py로 실행한다.",
-        ],
-        integration_notes=[
-            "서비스별 콘텐츠 JSON이 outputs/ 아래에 존재해야 한다.",
-            "app.py는 self-contained 템플릿으로 정규화된다.",
-        ],
+        runtime_notes=runtime_notes,
+        integration_notes=integration_notes,
     )
+
+
+def _build_app_source(input_model: PrototypeBuilderInput) -> str:
+    spec = input_model.implementation_spec
+    service_name = spec.service_name or "교육 서비스 MVP"
+    content_filename = build_content_filename(service_name)
+    source_path = Path(spec.source_path)
+
+    if _is_planning_package_dir(source_path):
+        package = load_planning_package(source_path)
+        score_rules = dict(package.evaluation_spec.score_rules)
+        grade_levels = list(package.evaluation_spec.grade_levels)
+        grade_thresholds = _normalize_grade_thresholds(
+            score_rules.get("service_grades", {}),
+            grade_levels,
+        )
+        return build_streamlit_app_source(
+            service_name=service_name,
+            content_filename=content_filename,
+            screens=list(package.interface_spec.screens),
+            api_endpoints=list(package.interface_spec.api_endpoints),
+            score_rules=score_rules,
+            grade_levels=grade_levels,
+            grade_thresholds=grade_thresholds,
+        )
+
+    return build_streamlit_app_source(
+        service_name=service_name,
+        content_filename=content_filename,
+    )
+
+
+def _normalize_grade_thresholds(
+    service_grades: object,
+    grade_levels: list[str],
+) -> dict[str, dict[str, int | None]]:
+    if not isinstance(service_grades, dict):
+        return {}
+
+    thresholds: dict[str, dict[str, int | None]] = {}
+    for grade in grade_levels:
+        raw_rule = service_grades.get(grade)
+        min_score = 0
+        max_score: int | None = None
+        if isinstance(raw_rule, (list, tuple)) and raw_rule:
+            first = raw_rule[0]
+            second = raw_rule[1] if len(raw_rule) > 1 else None
+            min_score = int(first) if first is not None else 0
+            max_score = int(second) if second is not None else None
+        thresholds[grade] = {
+            "min_score": min_score,
+            "max_score": max_score,
+        }
+    return thresholds
+
+
+def _is_planning_package_dir(path: Path) -> bool:
+    expected_files = {
+        "constitution.md",
+        "data_schema.json",
+        "state_machine.md",
+        "prompt_spec.md",
+        "interface_spec.md",
+        "pytest.py",
+    }
+    return path.is_dir() and all((path / file_name).exists() for file_name in expected_files)

--- a/orchestrator/app_source.py
+++ b/orchestrator/app_source.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import re
 import textwrap
+from pprint import pformat
+from string import Template
 
 
 def build_content_filename(service_name: str) -> str:
@@ -11,9 +13,42 @@ def build_content_filename(service_name: str) -> str:
     return f"{normalized or 'service_output'}_contents.json"
 
 
-def build_streamlit_app_source(service_name: str, content_filename: str) -> str:
-    """Return a self-contained Streamlit quiz app source string."""
+def build_streamlit_app_source(
+    service_name: str,
+    content_filename: str,
+    *,
+    screens: list[str] | None = None,
+    api_endpoints: list[str] | None = None,
+    score_rules: dict | None = None,
+    grade_levels: list[str] | None = None,
+    grade_thresholds: dict | None = None,
+) -> str:
+    """Return a self-contained Streamlit app source string.
 
+    When Quest package metadata is provided, generate the session-based Quest MVP template.
+    Otherwise fall back to the generic quiz viewer used by the legacy Markdown path.
+    """
+
+    if (
+        screens
+        and api_endpoints is not None
+        and score_rules is not None
+        and grade_levels
+        and grade_thresholds is not None
+    ):
+        return _build_quest_streamlit_app_source(
+            service_name=service_name,
+            content_filename=content_filename,
+            screens=screens,
+            api_endpoints=api_endpoints,
+            score_rules=score_rules,
+            grade_levels=grade_levels,
+            grade_thresholds=grade_thresholds,
+        )
+    return _build_generic_streamlit_app_source(service_name, content_filename)
+
+
+def _build_generic_streamlit_app_source(service_name: str, content_filename: str) -> str:
     return textwrap.dedent(
         f'''
         from __future__ import annotations
@@ -112,3 +147,580 @@ def build_streamlit_app_source(service_name: str, content_filename: str) -> str:
         main()
         '''
     ).strip() + "\n"
+
+
+def _build_quest_streamlit_app_source(
+    *,
+    service_name: str,
+    content_filename: str,
+    screens: list[str],
+    api_endpoints: list[str],
+    score_rules: dict,
+    grade_levels: list[str],
+    grade_thresholds: dict,
+) -> str:
+    template = Template(
+        textwrap.dedent(
+            """
+            from __future__ import annotations
+
+            import json
+            import re
+            from pathlib import Path
+            from typing import Any
+            from uuid import uuid4
+
+            import streamlit as st
+
+            SERVICE_NAME = $SERVICE_NAME
+            OUTPUT_PATH = Path(__file__).resolve().parent / "outputs" / $CONTENT_FILENAME
+            SCREENS = $SCREENS
+            API_ENDPOINTS = $API_ENDPOINTS
+            SCORE_RULES = $SCORE_RULES
+            GRADE_LEVELS = $GRADE_LEVELS
+            GRADE_THRESHOLDS = $GRADE_THRESHOLDS
+
+            SCREEN_START = SCREENS[0] if len(SCREENS) > 0 else "S0"
+            SCREEN_MULTIPLE_CHOICE = SCREENS[1] if len(SCREENS) > 1 else "S1"
+            SCREEN_MULTIPLE_CHOICE_RESULT = SCREENS[2] if len(SCREENS) > 2 else "S2"
+            SCREEN_IMPROVEMENT = SCREENS[3] if len(SCREENS) > 3 else "S3"
+            SCREEN_IMPROVEMENT_RESULT = SCREENS[4] if len(SCREENS) > 4 else "S4"
+            SCREEN_SESSION_RESULT = SCREENS[5] if len(SCREENS) > 5 else "S5"
+
+            IMPROVEMENT_MIN_LENGTH = 10
+            IMPROVEMENT_MAX_LENGTH = 300
+            SPECIFICITY_MARKERS = [
+                "예시", "단계", "문장", "문단", "그래프", "수식", "비유", "원인", "방법", "비교",
+                "3개", "한 문장", "단계별", "구체", "어떤 문제", "왜", "어떻게"
+            ]
+            CONTEXT_MARKERS = [
+                "국어", "수학", "과학", "사회", "역사", "영어", "숙제", "발표", "시험", "수행평가",
+                "수업", "실험", "독후감", "글쓰기", "프로젝트", "과제"
+            ]
+            PURPOSE_MARKERS = [
+                "설명", "예시", "풀이", "방법", "이유", "비교", "알려줘", "보여줘", "정리",
+                "도와줘", "알고 싶", "말해줘", "어떻게", "왜"
+            ]
+
+
+            def load_quest_contents() -> dict[str, Any]:
+                if not OUTPUT_PATH.exists():
+                    return {}
+                return json.loads(OUTPUT_PATH.read_text(encoding="utf-8"))
+
+
+            def ensure_state() -> None:
+                defaults = {
+                    "current_screen": SCREEN_START,
+                    "session_id": "",
+                    "session_quests": [],
+                    "current_quest_index": 0,
+                    "session_score": 0,
+                    "cumulative_score": 0,
+                    "current_grade": GRADE_LEVELS[0] if GRADE_LEVELS else "",
+                    "completed_session_count": 0,
+                    "last_result": None,
+                    "last_submission": "",
+                    "session_finalized": False,
+                    "grade_up_event": None,
+                    "previous_grade": GRADE_LEVELS[0] if GRADE_LEVELS else "",
+                    "last_api_response": None,
+                }
+                for key, value in defaults.items():
+                    st.session_state.setdefault(key, value)
+
+
+            def reset_session_progress() -> None:
+                st.session_state.session_id = ""
+                st.session_state.session_quests = []
+                st.session_state.current_quest_index = 0
+                st.session_state.session_score = 0
+                st.session_state.last_result = None
+                st.session_state.last_submission = ""
+                st.session_state.session_finalized = False
+                st.session_state.grade_up_event = None
+                st.session_state.last_api_response = None
+                st.session_state.current_screen = SCREEN_START
+
+
+            def truncate_feedback(text: str, limit: int = 150) -> str:
+                compact = " ".join(text.split())
+                return compact[:limit].rstrip()
+
+
+            def contains_any(text: str, markers: list[str]) -> bool:
+                lowered = text.lower()
+                return any(marker.lower() in lowered for marker in markers)
+
+
+            def get_grade_rank(grade: str) -> int:
+                try:
+                    return GRADE_LEVELS.index(grade)
+                except ValueError:
+                    return -1
+
+
+            def determine_grade(score: int) -> str:
+                for grade in GRADE_LEVELS:
+                    rule = GRADE_THRESHOLDS.get(grade, {})
+                    min_score = int(rule.get("min_score", 0))
+                    max_score = rule.get("max_score")
+                    if score >= min_score and (max_score is None or score <= int(max_score)):
+                        return grade
+                return GRADE_LEVELS[0] if GRADE_LEVELS else ""
+
+
+            def normalize_quest(item: dict[str, Any], difficulty: str) -> dict[str, Any]:
+                quest = dict(item)
+                quest.setdefault("difficulty", difficulty)
+                quest.setdefault("topic_context", quest.get("learning_dimension") or SERVICE_NAME)
+                quest.setdefault("original_question", quest.get("question") or "질문을 더 좋게 만들어 보세요.")
+                quest.setdefault("options", list(quest.get("choices", [])))
+                if quest.get("correct_choice") in quest.get("options", []):
+                    quest.setdefault("correct_option_index", quest["options"].index(quest["correct_choice"]))
+                else:
+                    quest.setdefault("correct_option_index", None)
+                return quest
+
+
+            def build_session_quests(data: dict[str, Any]) -> list[dict[str, Any]]:
+                items = list(data.get("items", []))
+                multiple_choice = [
+                    normalize_quest(item, "intro")
+                    for item in items
+                    if item.get("quiz_type") == "multiple_choice"
+                ]
+                question_improvement = [
+                    normalize_quest(item, "main")
+                    for item in items
+                    if item.get("quiz_type") == "question_improvement"
+                ]
+                if len(multiple_choice) < 1 or len(question_improvement) < 2:
+                    raise ValueError(
+                        "세션을 구성하려면 multiple_choice 1개와 question_improvement 2개가 필요합니다."
+                    )
+                return [
+                    multiple_choice[0],
+                    question_improvement[0],
+                    question_improvement[1],
+                ]
+
+
+            def calculate_multiple_choice_score(is_correct: bool) -> int:
+                rules = SCORE_RULES.get("answer_score_rules", {})
+                return int(
+                    rules.get(
+                        "multiple_choice_correct" if is_correct else "multiple_choice_incorrect",
+                        20 if is_correct else 5,
+                    )
+                )
+
+
+            def calculate_improvement_score(overall: str) -> int:
+                rules = SCORE_RULES.get("answer_score_rules", {})
+                default_map = {
+                    "excellent": 30,
+                    "good": 20,
+                    "needs_work": 10,
+                }
+                return int(rules.get(f"improvement_{overall}", default_map.get(overall, 10)))
+
+
+            def evaluate_specificity(text: str) -> str:
+                cleaned = text.strip()
+                marker_hit = contains_any(cleaned, SPECIFICITY_MARKERS) or bool(re.search(r"\\d", cleaned))
+                if len(cleaned) >= 28 and marker_hit:
+                    return "excellent"
+                if len(cleaned) >= 18 or marker_hit:
+                    return "good"
+                return "needs_work"
+
+
+            def evaluate_context(text: str) -> str:
+                cleaned = text.strip()
+                marker_count = sum(1 for marker in CONTEXT_MARKERS if marker in cleaned)
+                if marker_count >= 2:
+                    return "excellent"
+                if marker_count >= 1:
+                    return "good"
+                return "needs_work"
+
+
+            def evaluate_purpose(text: str) -> str:
+                cleaned = text.strip()
+                marker_count = sum(1 for marker in PURPOSE_MARKERS if marker in cleaned)
+                if marker_count >= 2 and len(cleaned) >= 22:
+                    return "excellent"
+                if marker_count >= 1:
+                    return "good"
+                return "needs_work"
+
+
+            def evaluate_improvement_response(text: str) -> dict[str, str]:
+                specificity = evaluate_specificity(text)
+                context = evaluate_context(text)
+                purpose = evaluate_purpose(text)
+                grades = [specificity, context, purpose]
+                if all(grade == "excellent" for grade in grades):
+                    overall = "excellent"
+                elif any(grade == "needs_work" for grade in grades):
+                    overall = "needs_work"
+                else:
+                    overall = "good"
+                return {
+                    "specificity": specificity,
+                    "context": context,
+                    "purpose": purpose,
+                    "overall": overall,
+                }
+
+
+            def build_improvement_feedback(rubric: dict[str, str]) -> str:
+                messages: list[str] = []
+                if rubric.get("specificity") == "excellent":
+                    messages.append("무엇을 묻는지가 구체적으로 드러나요.")
+                elif rubric.get("specificity") == "good":
+                    messages.append("질문의 대상은 보이지만 조건을 조금 더 넣으면 좋아요.")
+                else:
+                    messages.append("무엇을 궁금해하는지 더 구체적으로 적어보세요.")
+
+                if rubric.get("context") == "excellent":
+                    messages.append("과목이나 과제 상황이 분명해져요.")
+                elif rubric.get("context") == "good":
+                    messages.append("맥락 단서가 일부 보이지만 상황을 더 드러낼 수 있어요.")
+                else:
+                    messages.append("국어 숙제, 발표 준비처럼 학습 상황을 넣어보세요.")
+
+                if rubric.get("purpose") == "excellent":
+                    messages.append("원하는 도움의 형태가 분명해요.")
+                elif rubric.get("purpose") == "good":
+                    messages.append("도움 요청은 있지만 어떤 답을 원하는지 더 말해보세요.")
+                else:
+                    messages.append("예시, 풀이, 이유처럼 원하는 도움 형태를 함께 써보세요.")
+
+                header_map = {
+                    "excellent": "질문이 아주 명확해졌어요!",
+                    "good": "좋아졌어요!",
+                    "needs_work": "한 부분만 더 보완해볼까요?",
+                }
+                return truncate_feedback(f"{header_map.get(rubric.get('overall'), '좋아졌어요!')} {' '.join(messages)}")
+
+
+            def build_multiple_choice_feedback(quest: dict[str, Any], is_correct: bool) -> str:
+                base = quest.get("explanation", "정답 선택지가 더 좋은 질문입니다.")
+                prefix = "정답입니다!" if is_correct else "이 질문도 좋아요."
+                return truncate_feedback(f"{prefix} {base}")
+
+
+            def api_session_start() -> dict[str, Any]:
+                data = load_quest_contents()
+                session_quests = build_session_quests(data)
+                response = {
+                    "session_id": str(uuid4()),
+                    "quests": session_quests,
+                    "user_progress": {
+                        "cumulative_score": st.session_state.cumulative_score,
+                        "current_grade": st.session_state.current_grade,
+                        "completed_session_count": st.session_state.completed_session_count,
+                    },
+                }
+                st.session_state.session_id = response["session_id"]
+                st.session_state.session_quests = session_quests
+                st.session_state.current_quest_index = 0
+                st.session_state.session_score = 0
+                st.session_state.last_result = None
+                st.session_state.last_submission = ""
+                st.session_state.session_finalized = False
+                st.session_state.grade_up_event = None
+                st.session_state.last_api_response = response
+                st.session_state.current_screen = SCREEN_MULTIPLE_CHOICE
+                return response
+
+
+            def api_quest_submit(user_response: Any) -> dict[str, Any]:
+                quest = st.session_state.session_quests[st.session_state.current_quest_index]
+                is_session_complete = (
+                    st.session_state.current_quest_index == len(st.session_state.session_quests) - 1
+                )
+
+                if quest.get("quiz_type") == "multiple_choice":
+                    is_correct = user_response == quest.get("correct_choice")
+                    earned_score = calculate_multiple_choice_score(is_correct)
+                    response = {
+                        "answer_id": str(uuid4()),
+                        "evaluation": {
+                            "evaluation_type": "correctness",
+                            "is_correct": is_correct,
+                            "feedback": build_multiple_choice_feedback(quest, is_correct),
+                        },
+                        "earned_score": earned_score,
+                        "correct_option_index": quest.get("correct_option_index"),
+                        "is_session_complete": is_session_complete,
+                    }
+                    st.session_state.current_screen = SCREEN_MULTIPLE_CHOICE_RESULT
+                else:
+                    rubric = evaluate_improvement_response(str(user_response))
+                    overall = rubric["overall"]
+                    earned_score = calculate_improvement_score(overall)
+                    response = {
+                        "answer_id": str(uuid4()),
+                        "evaluation": {
+                            "evaluation_type": "rubric",
+                            "rubric_result": rubric,
+                            "feedback": build_improvement_feedback(rubric),
+                        },
+                        "earned_score": earned_score,
+                        "is_session_complete": is_session_complete,
+                    }
+                    st.session_state.current_screen = SCREEN_IMPROVEMENT_RESULT
+
+                st.session_state.session_score += int(response["earned_score"])
+                st.session_state.last_result = response
+                st.session_state.last_submission = str(user_response)
+                st.session_state.last_api_response = response
+                return response
+
+
+            def api_session_result() -> dict[str, Any]:
+                if not st.session_state.session_finalized:
+                    previous_grade = st.session_state.current_grade
+                    cumulative_score = st.session_state.cumulative_score + st.session_state.session_score
+                    new_grade = determine_grade(cumulative_score)
+                    grade_up_event = get_grade_rank(new_grade) > get_grade_rank(previous_grade)
+                    st.session_state.previous_grade = previous_grade
+                    st.session_state.cumulative_score = cumulative_score
+                    st.session_state.current_grade = new_grade
+                    st.session_state.completed_session_count += 1
+                    st.session_state.session_finalized = True
+                    st.session_state.grade_up_event = {
+                        "grade_up_event": grade_up_event,
+                        "previous_grade": previous_grade,
+                        "new_grade": new_grade,
+                    }
+
+                grade_event = st.session_state.grade_up_event or {
+                    "grade_up_event": False,
+                    "previous_grade": st.session_state.current_grade,
+                    "new_grade": st.session_state.current_grade,
+                }
+                response = {
+                    "session_id": st.session_state.session_id,
+                    "session_score": st.session_state.session_score,
+                    "user_progress": {
+                        "cumulative_score": st.session_state.cumulative_score,
+                        "current_grade": st.session_state.current_grade,
+                        "completed_session_count": st.session_state.completed_session_count,
+                    },
+                    "grade_up_event": grade_event["grade_up_event"],
+                    "previous_grade": grade_event["previous_grade"],
+                    "new_grade": grade_event["new_grade"],
+                }
+                st.session_state.last_api_response = response
+                return response
+
+
+            def render_sidebar() -> None:
+                with st.sidebar:
+                    st.subheader("세션 상태")
+                    st.write(f"현재 화면: {st.session_state.current_screen}")
+                    st.write(f"현재 등급: {st.session_state.current_grade or '없음'}")
+                    st.write(f"누적 점수: {st.session_state.cumulative_score}")
+                    st.write(f"세션 점수: {st.session_state.session_score}")
+                    st.subheader("화면 구성")
+                    for screen in SCREENS:
+                        st.write(f"- {screen}")
+                    st.subheader("내부 API")
+                    for endpoint in API_ENDPOINTS:
+                        st.write(f"- {endpoint}")
+                    st.caption(f"콘텐츠 파일: {OUTPUT_PATH.name}")
+
+
+            def render_start_screen() -> None:
+                st.title("오늘의 질문력 퀘스트")
+                st.caption(SERVICE_NAME)
+                st.write("3개의 퀘스트를 풀고 질문력 점수를 쌓아보세요!")
+                col1, col2 = st.columns(2)
+                col1.metric("현재 등급", st.session_state.current_grade or "-")
+                col2.metric("누적 점수", st.session_state.cumulative_score)
+                if st.button("세션 시작", type="primary"):
+                    try:
+                        api_session_start()
+                    except ValueError as error:
+                        st.error(str(error))
+                    else:
+                        st.rerun()
+
+
+            def render_multiple_choice_screen() -> None:
+                quest = st.session_state.session_quests[st.session_state.current_quest_index]
+                st.subheader("객관식 퀘스트")
+                st.caption(f"퀘스트 {st.session_state.current_quest_index + 1} / {len(st.session_state.session_quests)}")
+                st.write(f"학습 맥락: {quest.get('topic_context') or SERVICE_NAME}")
+                st.write(f"원본 질문: {quest.get('original_question') or quest.get('question')}")
+                st.info(quest.get("question") or "이 질문을 더 좋게 바꾼 선택지를 골라보세요.")
+                choice_key = f"choice_{quest['item_id']}"
+                st.radio("선택지를 고르세요.", quest.get("options", []), index=None, key=choice_key)
+                if st.button("제출", type="primary"):
+                    selected = st.session_state.get(choice_key)
+                    if not selected:
+                        st.warning("선택지를 골라주세요.")
+                    else:
+                        api_quest_submit(selected)
+                        st.rerun()
+
+
+            def render_multiple_choice_result() -> None:
+                quest = st.session_state.session_quests[st.session_state.current_quest_index]
+                result = st.session_state.last_result or {}
+                evaluation = result.get("evaluation", {})
+                is_correct = bool(evaluation.get("is_correct"))
+                st.subheader("객관식 결과")
+                st.success("정답입니다!" if is_correct else "이 질문도 좋아요")
+                st.write(f"내가 고른 답: {st.session_state.last_submission or '미응답'}")
+                st.write(f"정답: {quest.get('correct_choice', '-')}")
+                st.write(f"해설: {evaluation.get('feedback', quest.get('explanation', ''))}")
+                st.write(f"획득 점수: +{result.get('earned_score', 0)}점")
+                if st.button("다음 퀘스트로", type="primary"):
+                    st.session_state.current_quest_index += 1
+                    st.session_state.last_result = None
+                    st.session_state.last_submission = ""
+                    st.session_state.current_screen = SCREEN_IMPROVEMENT
+                    st.rerun()
+
+
+            def render_improvement_screen() -> None:
+                quest = st.session_state.session_quests[st.session_state.current_quest_index]
+                st.subheader("질문 더 좋게 만들기")
+                st.caption(f"퀘스트 {st.session_state.current_quest_index + 1} / {len(st.session_state.session_quests)}")
+                st.write(f"학습 맥락: {quest.get('topic_context') or SERVICE_NAME}")
+                st.write(f"원본 질문: {quest.get('original_question') or quest.get('question')}")
+                st.info("이 질문을 더 명확하게 바꿔보세요. 무엇을, 왜, 어떻게가 들어가면 좋아요.")
+                text_key = f"text_{quest['item_id']}"
+                user_text = st.text_area(
+                    "질문 다시 쓰기",
+                    key=text_key,
+                    max_chars=IMPROVEMENT_MAX_LENGTH,
+                    height=180,
+                )
+                st.caption(f"{len(user_text)} / {IMPROVEMENT_MAX_LENGTH}")
+                if st.button("제출", type="primary"):
+                    if not user_text.strip():
+                        st.warning("질문을 작성해주세요.")
+                    elif len(user_text.strip()) < IMPROVEMENT_MIN_LENGTH:
+                        st.warning("조금 더 자세히 작성해주세요 (최소 10자).")
+                    else:
+                        api_quest_submit(user_text.strip())
+                        st.rerun()
+
+
+            def render_improvement_result() -> None:
+                quest = st.session_state.session_quests[st.session_state.current_quest_index]
+                result = st.session_state.last_result or {}
+                evaluation = result.get("evaluation", {})
+                rubric = evaluation.get("rubric_result", {})
+                overall = rubric.get("overall", "good")
+                header_map = {
+                    "excellent": "아주 명확해졌어요!",
+                    "good": "좋아졌어요!",
+                    "needs_work": "한 부분만 더 보완해볼까요?",
+                }
+                st.subheader("개선형 퀘스트 결과")
+                st.success(header_map.get(overall, "좋아졌어요!"))
+                col1, col2 = st.columns(2)
+                col1.markdown("**Before**")
+                col1.write(quest.get("original_question") or quest.get("question"))
+                col2.markdown("**After**")
+                col2.write(st.session_state.last_submission or "미응답")
+                st.write(
+                    " / ".join(
+                        [
+                            f"구체성: {rubric.get('specificity', '-')}",
+                            f"맥락성: {rubric.get('context', '-')}",
+                            f"목적성: {rubric.get('purpose', '-')}",
+                        ]
+                    )
+                )
+                st.write(f"피드백: {evaluation.get('feedback', '')}")
+                st.write(f"획득 점수: +{result.get('earned_score', 0)}점")
+                button_label = (
+                    "결과 보기"
+                    if st.session_state.current_quest_index >= len(st.session_state.session_quests) - 1
+                    else "다음 퀘스트로"
+                )
+                if st.button(button_label, type="primary"):
+                    st.session_state.last_result = None
+                    st.session_state.last_submission = ""
+                    if st.session_state.current_quest_index >= len(st.session_state.session_quests) - 1:
+                        st.session_state.current_screen = SCREEN_SESSION_RESULT
+                    else:
+                        st.session_state.current_quest_index += 1
+                        next_quest = st.session_state.session_quests[st.session_state.current_quest_index]
+                        st.session_state.current_screen = (
+                            SCREEN_MULTIPLE_CHOICE
+                            if next_quest.get("quiz_type") == "multiple_choice"
+                            else SCREEN_IMPROVEMENT
+                        )
+                    st.rerun()
+
+
+            def render_session_result() -> None:
+                result = api_session_result()
+                st.subheader("오늘의 퀘스트 완료!")
+                col1, col2, col3 = st.columns(3)
+                col1.metric("이번 세션 점수", f"+{result['session_score']}점")
+                col2.metric("누적 총점", result["user_progress"]["cumulative_score"])
+                col3.metric("현재 등급", result["user_progress"]["current_grade"])
+                if result.get("grade_up_event"):
+                    st.success(f"축하해요! 이제 {result.get('new_grade')} 단계예요")
+                st.write(f"완료한 세션 수: {result['user_progress']['completed_session_count']}")
+                col_a, col_b = st.columns(2)
+                if col_a.button("새 세션 시작", type="primary"):
+                    reset_session_progress()
+                    st.rerun()
+                if col_b.button("종료"):
+                    reset_session_progress()
+                    st.rerun()
+
+
+            def main() -> None:
+                st.set_page_config(page_title=f"{SERVICE_NAME} MVP", page_icon="🧭", layout="wide")
+                ensure_state()
+                render_sidebar()
+
+                if not OUTPUT_PATH.exists():
+                    st.warning(f"{OUTPUT_PATH.name}이 아직 없습니다. 먼저 파이프라인을 실행하세요.")
+
+                screen = st.session_state.current_screen
+                if screen == SCREEN_START:
+                    render_start_screen()
+                elif screen == SCREEN_MULTIPLE_CHOICE:
+                    render_multiple_choice_screen()
+                elif screen == SCREEN_MULTIPLE_CHOICE_RESULT:
+                    render_multiple_choice_result()
+                elif screen == SCREEN_IMPROVEMENT:
+                    render_improvement_screen()
+                elif screen == SCREEN_IMPROVEMENT_RESULT:
+                    render_improvement_result()
+                elif screen == SCREEN_SESSION_RESULT:
+                    render_session_result()
+                else:
+                    st.error(f"알 수 없는 화면 상태입니다: {screen}")
+
+
+            main()
+            """
+        )
+    )
+    return template.substitute(
+        SERVICE_NAME=_python_literal(service_name),
+        CONTENT_FILENAME=_python_literal(content_filename),
+        SCREENS=_python_literal(screens),
+        API_ENDPOINTS=_python_literal(api_endpoints),
+        SCORE_RULES=_python_literal(score_rules),
+        GRADE_LEVELS=_python_literal(grade_levels),
+        GRADE_THRESHOLDS=_python_literal(grade_thresholds),
+    ).strip() + "\n"
+
+
+def _python_literal(value: object) -> str:
+    return pformat(value, width=88, sort_dicts=False)

--- a/orchestrator/pipeline.py
+++ b/orchestrator/pipeline.py
@@ -14,7 +14,7 @@ from agents.implementation.requirement_mapping_agent import run_requirement_mapp
 from agents.implementation.run_test_and_fix_agent import run_run_test_and_fix_agent
 from agents.implementation.spec_intake_agent import run_spec_intake_agent
 from clients.llm import LLMClient
-from orchestrator.app_source import build_content_filename, build_streamlit_app_source
+from orchestrator.app_source import build_content_filename
 from schemas.implementation.common import LocalCheckResult, SchemaModel
 from schemas.implementation.content_interaction import ContentInteractionInput
 from schemas.implementation.implementation_spec import ImplementationSpec, parse_markdown_spec
@@ -96,6 +96,7 @@ class ImplementationPipeline:
                     spec_intake_output=spec_intake_output,
                     requirement_mapping_output=requirement_mapping_output,
                     content_interaction_output=content_interaction_output,
+                    implementation_spec=spec,
                 ),
                 self.llm_client,
             ),
@@ -200,20 +201,21 @@ class ImplementationPipeline:
         content_filename: str,
     ) -> None:
         output.service_name = service_name
-        output.runtime_notes = [
-            f"app.py는 outputs/{content_filename}을 읽는다.",
-            "streamlit run app.py로 실행한다.",
-        ]
-        output.integration_notes = [
-            f"{content_filename}이 outputs/ 아래에 존재해야 한다.",
-            "app.py는 self-contained 템플릿으로 정규화된다.",
-        ]
+        output.runtime_notes = _dedupe_preserve_order(
+            [
+                *output.runtime_notes,
+                f"app.py는 outputs/{content_filename}을 읽는다.",
+                "streamlit run app.py로 실행한다.",
+            ]
+        )
+        output.integration_notes = _dedupe_preserve_order(
+            [
+                *output.integration_notes,
+                f"{content_filename}이 outputs/ 아래에 존재해야 한다.",
+            ]
+        )
         for generated_file in output.generated_files:
             if Path(generated_file.path).name == "app.py":
-                generated_file.content = build_streamlit_app_source(
-                    service_name=service_name,
-                    content_filename=content_filename,
-                )
                 generated_file.description = (
                     f"{service_name} 콘텐츠를 읽는 self-contained Streamlit MVP app."
                 )
@@ -413,3 +415,14 @@ class ImplementationPipeline:
     def _log(self, message: str) -> None:
         self.logs.append(message)
         print(message, flush=True)
+
+
+def _dedupe_preserve_order(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    ordered: list[str] = []
+    for value in values:
+        if value in seen:
+            continue
+        seen.add(value)
+        ordered.append(value)
+    return ordered

--- a/schemas/implementation/common.py
+++ b/schemas/implementation/common.py
@@ -25,10 +25,22 @@ class QuizGenerationRequirements(SchemaModel):
 class QuizItem(SchemaModel):
     item_id: str = Field(description="Unique quiz item identifier.")
     quiz_type: str = Field(description="Quiz type or category for the item.")
+    difficulty: str = Field(
+        default="",
+        description="Optional difficulty level such as intro or main.",
+    )
     learning_dimension: str = Field(
         description="Question-power dimension targeted by the quiz item."
     )
     title: str = Field(description="Short display title for the item.")
+    topic_context: str = Field(
+        default="",
+        description="Optional topic or learning context shown with the item.",
+    )
+    original_question: str = Field(
+        default="",
+        description="Optional original learner question used by Quest-style flows.",
+    )
     question: str = Field(description="Question text shown to the learner.")
     choices: list[str] = Field(description="Multiple-choice options.")
     correct_choice: str = Field(description="Correct answer string from the choices.")

--- a/schemas/implementation/prototype_builder.py
+++ b/schemas/implementation/prototype_builder.py
@@ -4,6 +4,7 @@ from pydantic import Field
 
 from schemas.implementation.common import AgentLabel, GeneratedFile, SchemaModel
 from schemas.implementation.content_interaction import ContentInteractionOutput
+from schemas.implementation.implementation_spec import ImplementationSpec
 from schemas.implementation.requirement_mapping import RequirementMappingOutput
 from schemas.implementation.spec_intake import SpecIntakeOutput
 
@@ -17,6 +18,9 @@ class PrototypeBuilderInput(SchemaModel):
     )
     content_interaction_output: ContentInteractionOutput = Field(
         description="Generated content and interaction data for the MVP."
+    )
+    implementation_spec: ImplementationSpec = Field(
+        description="Runtime implementation configuration for the current service."
     )
 
 

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -110,6 +110,7 @@ class FakeLLMClient:
                 DEFAULT_LEARNING_DIMENSIONS
             )
             total_count = _extract_int_from_prompt(prompt, "total_count", default=8)
+            items_per_type = _extract_int_from_prompt(prompt, "items_per_type", default=2)
             service_name = _extract_scalar_from_prompt(prompt, "service_name") or "교육 서비스"
 
             if (
@@ -123,8 +124,12 @@ class FakeLLMClient:
             answer_key = {}
             explanations = {}
             learning_points = {}
-            for index in range(total_count):
-                quiz_type = content_types[index % len(content_types)] if content_types else "generic"
+            quiz_type_sequence = _build_quiz_type_sequence(
+                content_types,
+                total_count=total_count,
+                items_per_type=items_per_type,
+            )
+            for index, quiz_type in enumerate(quiz_type_sequence):
                 learning_dimension = (
                     learning_dimensions[index % len(learning_dimensions)]
                     if learning_dimensions
@@ -141,8 +146,11 @@ class FakeLLMClient:
                     {
                         "item_id": item_id,
                         "quiz_type": quiz_type,
+                        "difficulty": "intro" if quiz_type == "multiple_choice" else "main",
                         "learning_dimension": learning_dimension,
                         "title": title,
+                        "topic_context": _build_topic_context_for_type(quiz_type),
+                        "original_question": _build_original_question_for_type(quiz_type),
                         "question": question,
                         "choices": choices,
                         "correct_choice": correct,
@@ -186,8 +194,11 @@ class FakeLLMClient:
                 {
                     "item_id": item_id,
                     "quiz_type": quiz_type,
+                    "difficulty": "intro" if quiz_type == "multiple_choice" else "main",
                     "learning_dimension": learning_dimension,
                     "title": f"{quiz_type} 재생성 문항",
+                    "topic_context": _build_topic_context_for_type(quiz_type),
+                    "original_question": _build_original_question_for_type(quiz_type),
                     "question": _build_question_for_type(quiz_type),
                     "choices": _build_choices_for_type(quiz_type),
                     "correct_choice": _build_correct_choice_for_type(quiz_type),
@@ -376,6 +387,7 @@ class FakeLLMClient:
                 {
                     "item_id": item_id,
                     "quiz_type": quiz_type,
+                    "difficulty": "intro" if quiz_type in {"질문에서 빠진 요소 찾기", "더 좋은 질문 고르기"} else "main",
                     "learning_dimension": (
                         "구체성"
                         if item_id in {"quiz-02"}
@@ -384,6 +396,8 @@ class FakeLLMClient:
                         else "목적성"
                     ),
                     "title": title,
+                    "topic_context": _build_topic_context_for_type(quiz_type),
+                    "original_question": _build_original_question_for_type(quiz_type),
                     "question": question,
                     "choices": choices,
                     "correct_choice": correct,
@@ -419,7 +433,7 @@ def _build_question_for_type(quiz_type: str) -> str:
     if quiz_type == "multiple_choice":
         return "다음 중 더 좋은 질문으로 볼 수 있는 선택지는 무엇일까?"
     if quiz_type == "question_improvement":
-        return "모호한 질문을 더 구체적으로 고친 것은 무엇일까?"
+        return "원본 질문을 더 구체적이고 도움받기 쉬운 질문으로 다시 써보세요."
     if quiz_type == "질문에서 빠진 요소 찾기":
         return "질문 '이거 왜 그래?'에서 가장 먼저 보완해야 할 빠진 요소는 무엇일까?"
     if quiz_type == "모호한 질문 고치기":
@@ -475,6 +489,52 @@ def _build_correct_choice_for_type(quiz_type: str) -> str:
     if quiz_type == "상황에 맞는 질문 만들기":
         return "과학 발표 준비 중인데 화산이 폭발하는 원인을 한 문장으로 설명해 줄래?"
     return "국어 숙제인데 이 문장이 왜 비유인지 예시와 함께 설명해 줘."
+
+
+def _build_topic_context_for_type(quiz_type: str) -> str:
+    if quiz_type == "multiple_choice":
+        return "국어 비유 표현 학습"
+    if quiz_type == "question_improvement":
+        return "수학 일차방정식"
+    if quiz_type == "질문에서 빠진 요소 찾기":
+        return "과학 발표 준비"
+    if quiz_type == "모호한 질문 고치기":
+        return "사회 수행평가 준비"
+    if quiz_type == "상황에 맞는 질문 만들기":
+        return "글쓰기 과제"
+    return "학습 맥락"
+
+
+def _build_original_question_for_type(quiz_type: str) -> str:
+    if quiz_type == "multiple_choice":
+        return "비유가 뭔지 모르겠어"
+    if quiz_type == "question_improvement":
+        return "이거 어떻게 풀어"
+    if quiz_type == "질문에서 빠진 요소 찾기":
+        return "이거 왜 그래?"
+    if quiz_type == "모호한 질문 고치기":
+        return "왜 그랬어?"
+    if quiz_type == "상황에 맞는 질문 만들기":
+        return "도와줘."
+    return "이거 알려 줘."
+
+
+def _build_quiz_type_sequence(
+    content_types: list[str],
+    *,
+    total_count: int,
+    items_per_type: int,
+) -> list[str]:
+    if (
+        content_types == ["multiple_choice", "question_improvement"]
+        and total_count == 3
+        and items_per_type == 2
+    ):
+        return ["multiple_choice", "question_improvement", "question_improvement"]
+
+    if not content_types:
+        return ["generic"] * total_count
+    return [content_types[index % len(content_types)] for index in range(total_count)]
 
 
 def _build_explanation_for_dimension(dimension: str) -> str:

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -99,3 +99,13 @@ def test_pipeline_with_planning_package_generates_service_named_contents(tmp_pat
     payload = json.loads(content_path.read_text(encoding="utf-8"))
     assert len(payload["items"]) == 3
     assert set(payload["quiz_types"]) == {"multiple_choice", "question_improvement"}
+    assert [item["quiz_type"] for item in payload["items"]] == [
+        "multiple_choice",
+        "question_improvement",
+        "question_improvement",
+    ]
+    app_source = (tmp_path / "app.py").read_text(encoding="utf-8")
+    assert "def api_session_start()" in app_source
+    assert "def api_quest_submit(user_response: Any)" in app_source
+    assert "def api_session_result()" in app_source
+    assert content_filename in app_source

--- a/tests/test_prototype_builder_agent.py
+++ b/tests/test_prototype_builder_agent.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+from agents.implementation.prototype_builder_agent import run_prototype_builder_agent
+from loaders import load_planning_package, planning_package_to_implementation_spec
+from schemas.implementation.content_interaction import ContentInteractionOutput
+from schemas.implementation.prototype_builder import PrototypeBuilderInput
+from schemas.implementation.requirement_mapping import RequirementMappingOutput
+from schemas.implementation.spec_intake import SpecIntakeOutput
+from tests.fakes import FakeLLMClient
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+PACKAGE_DIR = REPO_ROOT / "inputs" / "mock_planning_outputs" / "question_quest_v0"
+
+
+def _build_package_content_output(fake: FakeLLMClient, service_name: str) -> ContentInteractionOutput:
+    prompt = "\n".join(
+        [
+            f"- service_name: {service_name}",
+            '- content_types: ["multiple_choice", "question_improvement"]',
+            '- learning_goals: ["구체성", "맥락성", "목적성"]',
+            "- total_count: 3",
+            "- items_per_type: 2",
+        ]
+    )
+    return fake.generate_json(prompt=prompt, response_model=ContentInteractionOutput)
+
+
+def test_prototype_builder_generates_quest_template_from_planning_package() -> None:
+    fake = FakeLLMClient()
+    package = load_planning_package(PACKAGE_DIR)
+    spec = planning_package_to_implementation_spec(package, PACKAGE_DIR)
+
+    output = run_prototype_builder_agent(
+        PrototypeBuilderInput(
+            spec_intake_output=fake.generate_json(prompt="", response_model=SpecIntakeOutput),
+            requirement_mapping_output=fake.generate_json(
+                prompt="",
+                response_model=RequirementMappingOutput,
+            ),
+            content_interaction_output=_build_package_content_output(fake, spec.service_name),
+            implementation_spec=spec,
+        ),
+        fake,
+    )
+
+    source = output.generated_files[0].content
+
+    assert "def api_session_start()" in source
+    assert "def api_quest_submit(user_response: Any)" in source
+    assert "def api_session_result()" in source
+    assert "SCREENS = ['S0', 'S1', 'S2', 'S3', 'S4', 'S5']" in source
+    assert "SCORE_RULES =" in source
+    assert "GRADE_LEVELS =" in source
+    assert "GRADE_THRESHOLDS =" in source
+    assert "question_quest_contents.json" in source
+    assert "load_planning_package" not in source
+    assert "constitution.md" not in source

--- a/tests/test_streamlit_mvp.py
+++ b/tests/test_streamlit_mvp.py
@@ -6,9 +6,17 @@ import sys
 import time
 from pathlib import Path
 
+from agents.implementation.prototype_builder_agent import run_prototype_builder_agent
+from loaders import load_planning_package, planning_package_to_implementation_spec
 from orchestrator.app_source import build_content_filename, build_streamlit_app_source
 from schemas.implementation.content_interaction import ContentInteractionOutput
+from schemas.implementation.prototype_builder import PrototypeBuilderInput
+from schemas.implementation.requirement_mapping import RequirementMappingOutput
+from schemas.implementation.spec_intake import SpecIntakeOutput
 from tests.fakes import FakeLLMClient
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
 def test_generated_streamlit_app_compiles_and_starts(tmp_path: Path) -> None:
@@ -48,6 +56,79 @@ def test_generated_streamlit_app_compiles_and_starts(tmp_path: Path) -> None:
             "true",
             "--server.port",
             "8766",
+        ],
+        cwd=tmp_path,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    time.sleep(3)
+    assert process.poll() is None
+    process.terminate()
+    output = process.communicate(timeout=5)[0]
+    assert "Traceback" not in output
+
+
+def test_generated_quest_streamlit_app_compiles_and_starts(tmp_path: Path) -> None:
+    app_path = tmp_path / "app.py"
+    output_dir = tmp_path / "outputs"
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    fake = FakeLLMClient()
+    package_dir = REPO_ROOT / "inputs" / "mock_planning_outputs" / "question_quest_v0"
+    package = load_planning_package(package_dir)
+    implementation_spec = planning_package_to_implementation_spec(package, package_dir)
+    content_filename = build_content_filename(implementation_spec.service_name)
+
+    content_output = fake.generate_json(
+        prompt="\n".join(
+            [
+                f"- service_name: {implementation_spec.service_name}",
+                '- content_types: ["multiple_choice", "question_improvement"]',
+                '- learning_goals: ["구체성", "맥락성", "목적성"]',
+                "- total_count: 3",
+                "- items_per_type: 2",
+            ]
+        ),
+        response_model=ContentInteractionOutput,
+    )
+    (output_dir / content_filename).write_text(
+        json.dumps(content_output.model_dump(mode="json"), ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+    builder_output = run_prototype_builder_agent(
+        PrototypeBuilderInput(
+            spec_intake_output=fake.generate_json(prompt="", response_model=SpecIntakeOutput),
+            requirement_mapping_output=fake.generate_json(
+                prompt="",
+                response_model=RequirementMappingOutput,
+            ),
+            content_interaction_output=content_output,
+            implementation_spec=implementation_spec,
+        ),
+        fake,
+    )
+    app_path.write_text(builder_output.generated_files[0].content, encoding="utf-8")
+
+    compile_result = subprocess.run(
+        [sys.executable, "-m", "py_compile", str(app_path)],
+        capture_output=True,
+        text=True,
+    )
+    assert compile_result.returncode == 0, compile_result.stderr
+
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "streamlit",
+            "run",
+            str(app_path),
+            "--server.headless",
+            "true",
+            "--server.port",
+            "8767",
         ],
         cwd=tmp_path,
         stdout=subprocess.PIPE,


### PR DESCRIPTION
## 작업 내용
- Prototype Builder가 planning package 입력일 때 Quest용 Streamlit 앱 템플릿을 생성하도록 변경
- app.py 생성 시 `SCREENS`, `API_ENDPOINTS`, `SCORE_RULES`, `GRADE_LEVELS`, `GRADE_THRESHOLDS`를 상수로 삽입
- generated app.py는 런타임에 package 파일을 다시 읽지 않고 outputs 콘텐츠 JSON만 사용
- S0~S5 상태기계와 `api_session_start()`, `api_quest_submit()`, `api_session_result()` 내부 함수를 구현
- 개선형 퀘스트 평가는 글자 수/키워드 기반 규칙으로 처리
- package 경로와 legacy 경로 모두 유지되도록 테스트 보강

## 검증
- `.venv/bin/python -m pytest -q`
- 결과: `25 passed`
