### PR TITLE
[codex] #21 Streamlit Cloud 배포 준비 정리

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,5 +6,6 @@ __pycache__/
 *.egg-info/
 .pytest_cache/
 .mypy_cache/
-.streamlit/
 outputs/latest_run/
+!.streamlit/
+!.streamlit/config.toml

--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,6 @@
+[theme]
+base = "light"
+primaryColor = "#2563EB"
+backgroundColor = "#FFFFFF"
+secondaryBackgroundColor = "#F3F4F6"
+textColor = "#111827"

--- a/app.py
+++ b/app.py
@@ -9,7 +9,11 @@ from uuid import uuid4
 import streamlit as st
 
 SERVICE_NAME = 'question_quest'
-OUTPUT_PATH = Path(__file__).resolve().parent / "outputs" / 'question_quest_contents.json'
+CONTENT_FILENAME = 'question_quest_contents.json'
+APP_DIR = Path(__file__).resolve().parent
+OUTPUT_PATH = APP_DIR / "outputs" / CONTENT_FILENAME
+FALLBACK_OUTPUT_PATH = APP_DIR / CONTENT_FILENAME
+CONTENT_CANDIDATE_PATHS = [OUTPUT_PATH, FALLBACK_OUTPUT_PATH]
 SCREENS = ['S0', 'S1', 'S2', 'S3', 'S4', 'S5']
 API_ENDPOINTS = ['/api/session/start', '/api/quest/submit', '/api/session/result']
 SCORE_RULES = {'rubric_grades': ['우수', '양호', '미흡'],
@@ -51,10 +55,22 @@ PURPOSE_MARKERS = [
 ]
 
 
+def resolve_content_path() -> Path | None:
+    for candidate in CONTENT_CANDIDATE_PATHS:
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def describe_content_paths() -> str:
+    return ", ".join(str(path) for path in CONTENT_CANDIDATE_PATHS)
+
+
 def load_quest_contents() -> dict[str, Any]:
-    if not OUTPUT_PATH.exists():
+    content_path = resolve_content_path()
+    if content_path is None:
         return {}
-    return json.loads(OUTPUT_PATH.read_text(encoding="utf-8"))
+    return json.loads(content_path.read_text(encoding="utf-8"))
 
 
 def ensure_state() -> None:
@@ -369,6 +385,7 @@ def api_session_result() -> dict[str, Any]:
 
 def render_sidebar() -> None:
     with st.sidebar:
+        content_path = resolve_content_path()
         st.subheader("세션 상태")
         st.write(f"현재 화면: {st.session_state.current_screen}")
         st.write(f"현재 등급: {st.session_state.current_grade or '없음'}")
@@ -380,7 +397,10 @@ def render_sidebar() -> None:
         st.subheader("내부 API")
         for endpoint in API_ENDPOINTS:
             st.write(f"- {endpoint}")
-        st.caption(f"콘텐츠 파일: {OUTPUT_PATH.name}")
+        if content_path is None:
+            st.caption(f"콘텐츠 파일: 없음 ({describe_content_paths()})")
+        else:
+            st.caption(f"콘텐츠 파일: {content_path}")
 
 
 def render_start_screen() -> None:
@@ -535,8 +555,12 @@ def main() -> None:
     ensure_state()
     render_sidebar()
 
-    if not OUTPUT_PATH.exists():
-        st.warning(f"{OUTPUT_PATH.name}이 아직 없습니다. 먼저 파이프라인을 실행하세요.")
+    content_path = resolve_content_path()
+    if content_path is None:
+        st.warning(
+            "콘텐츠 파일을 찾지 못했습니다. 먼저 파이프라인을 실행하거나 "
+            f"다음 경로 중 하나에 파일을 준비하세요: {describe_content_paths()}"
+        )
 
     screen = st.session_state.current_screen
     if screen == SCREEN_START:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+streamlit>=1.40,<2
+pydantic>=2,<3

--- a/tests/test_streamlit_mvp.py
+++ b/tests/test_streamlit_mvp.py
@@ -19,6 +19,59 @@ from tests.fakes import FakeLLMClient
 REPO_ROOT = Path(__file__).resolve().parents[1]
 
 
+def _assert_streamlit_app_starts(app_path: Path, *, cwd: Path, port: int) -> None:
+    compile_result = subprocess.run(
+        [sys.executable, "-m", "py_compile", str(app_path)],
+        capture_output=True,
+        text=True,
+    )
+    assert compile_result.returncode == 0, compile_result.stderr
+
+    process = subprocess.Popen(
+        [
+            sys.executable,
+            "-m",
+            "streamlit",
+            "run",
+            str(app_path),
+            "--server.headless",
+            "true",
+            "--server.port",
+            str(port),
+        ],
+        cwd=cwd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    time.sleep(3)
+    assert process.poll() is None
+    process.terminate()
+    output = process.communicate(timeout=5)[0]
+    assert "Traceback" not in output
+
+
+def _build_package_content_output() -> tuple[str, ContentInteractionOutput]:
+    fake = FakeLLMClient()
+    package_dir = REPO_ROOT / "inputs" / "mock_planning_outputs" / "question_quest_v0"
+    package = load_planning_package(package_dir)
+    implementation_spec = planning_package_to_implementation_spec(package, package_dir)
+    content_filename = build_content_filename(implementation_spec.service_name)
+    content_output = fake.generate_json(
+        prompt="\n".join(
+            [
+                f"- service_name: {implementation_spec.service_name}",
+                '- content_types: ["multiple_choice", "question_improvement"]',
+                '- learning_goals: ["구체성", "맥락성", "목적성"]',
+                "- total_count: 3",
+                "- items_per_type: 2",
+            ]
+        ),
+        response_model=ContentInteractionOutput,
+    )
+    return content_filename, content_output
+
+
 def test_generated_streamlit_app_compiles_and_starts(tmp_path: Path) -> None:
     app_path = tmp_path / "app.py"
     output_dir = tmp_path / "outputs"
@@ -38,35 +91,7 @@ def test_generated_streamlit_app_compiles_and_starts(tmp_path: Path) -> None:
         encoding="utf-8",
     )
 
-    compile_result = subprocess.run(
-        [sys.executable, "-m", "py_compile", str(app_path)],
-        capture_output=True,
-        text=True,
-    )
-    assert compile_result.returncode == 0, compile_result.stderr
-
-    process = subprocess.Popen(
-        [
-            sys.executable,
-            "-m",
-            "streamlit",
-            "run",
-            str(app_path),
-            "--server.headless",
-            "true",
-            "--server.port",
-            "8766",
-        ],
-        cwd=tmp_path,
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-    )
-    time.sleep(3)
-    assert process.poll() is None
-    process.terminate()
-    output = process.communicate(timeout=5)[0]
-    assert "Traceback" not in output
+    _assert_streamlit_app_starts(app_path, cwd=tmp_path, port=8766)
 
 
 def test_generated_quest_streamlit_app_compiles_and_starts(tmp_path: Path) -> None:
@@ -78,20 +103,8 @@ def test_generated_quest_streamlit_app_compiles_and_starts(tmp_path: Path) -> No
     package_dir = REPO_ROOT / "inputs" / "mock_planning_outputs" / "question_quest_v0"
     package = load_planning_package(package_dir)
     implementation_spec = planning_package_to_implementation_spec(package, package_dir)
-    content_filename = build_content_filename(implementation_spec.service_name)
+    content_filename, content_output = _build_package_content_output()
 
-    content_output = fake.generate_json(
-        prompt="\n".join(
-            [
-                f"- service_name: {implementation_spec.service_name}",
-                '- content_types: ["multiple_choice", "question_improvement"]',
-                '- learning_goals: ["구체성", "맥락성", "목적성"]',
-                "- total_count: 3",
-                "- items_per_type: 2",
-            ]
-        ),
-        response_model=ContentInteractionOutput,
-    )
     (output_dir / content_filename).write_text(
         json.dumps(content_output.model_dump(mode="json"), ensure_ascii=False, indent=2),
         encoding="utf-8",
@@ -111,6 +124,39 @@ def test_generated_quest_streamlit_app_compiles_and_starts(tmp_path: Path) -> No
     )
     app_path.write_text(builder_output.generated_files[0].content, encoding="utf-8")
 
+    _assert_streamlit_app_starts(app_path, cwd=tmp_path, port=8767)
+
+
+def test_root_app_reads_outputs_content_file(tmp_path: Path) -> None:
+    app_path = tmp_path / "app.py"
+    output_dir = tmp_path / "outputs"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    content_filename, content_output = _build_package_content_output()
+    app_path.write_text((REPO_ROOT / "app.py").read_text(encoding="utf-8"), encoding="utf-8")
+    (output_dir / content_filename).write_text(
+        json.dumps(content_output.model_dump(mode="json"), ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+    _assert_streamlit_app_starts(app_path, cwd=tmp_path, port=8768)
+
+
+def test_root_app_reads_root_fallback_content_file(tmp_path: Path) -> None:
+    app_path = tmp_path / "app.py"
+    content_filename, content_output = _build_package_content_output()
+    app_path.write_text((REPO_ROOT / "app.py").read_text(encoding="utf-8"), encoding="utf-8")
+    (tmp_path / content_filename).write_text(
+        json.dumps(content_output.model_dump(mode="json"), ensure_ascii=False, indent=2),
+        encoding="utf-8",
+    )
+
+    _assert_streamlit_app_starts(app_path, cwd=tmp_path, port=8769)
+
+
+def test_root_app_starts_without_content_file_and_shows_warning(tmp_path: Path) -> None:
+    app_path = tmp_path / "app.py"
+    app_path.write_text((REPO_ROOT / "app.py").read_text(encoding="utf-8"), encoding="utf-8")
+
     compile_result = subprocess.run(
         [sys.executable, "-m", "py_compile", str(app_path)],
         capture_output=True,
@@ -128,7 +174,7 @@ def test_generated_quest_streamlit_app_compiles_and_starts(tmp_path: Path) -> No
             "--server.headless",
             "true",
             "--server.port",
-            "8767",
+            "8770",
         ],
         cwd=tmp_path,
         stdout=subprocess.PIPE,


### PR DESCRIPTION
## 요약
- Streamlit Cloud 배포용 `requirements.txt`를 추가했습니다.
- `.streamlit/config.toml` 기본 테마를 추가했습니다.
- 루트 `app.py`가 `outputs/question_quest_contents.json`을 우선 읽고, 없으면 루트 `question_quest_contents.json`으로 fallback 하도록 정리했습니다.
- Streamlit smoke 테스트를 outputs 경로, 루트 fallback 경로, 콘텐츠 파일 부재 경로까지 보강했습니다.

## 검증
- `.venv/bin/python -m pytest -q`
- `.venv/bin/python -m streamlit run app.py --server.headless true --server.port 8521`
