### PR TITLE
[codex] 이슈 30 target_framework 추가 및 Streamlit 우선 지원

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,10 @@ export OPENAI_BASE_URL="https://api.openai.com/v1"  # optional
 .venv/bin/python main.py --input-path inputs/quiz_service_spec.md --output-dir outputs
 ```
 
+`target_framework`의 기본값은 `streamlit`이다. 현재 Prototype Builder가 실제로
+생성하는 앱은 Streamlit `app.py`뿐이며, `react`, `fastapi`, `nextjs` 같은 값은
+명확한 unsupported 결과와 로그를 남기고 local checks 전에 중단한다.
+
 ## Outputs 확인 방법
 
 실행이 끝나면 `outputs/` 아래에 아래 파일이 생성된다.

--- a/agents/implementation/prototype_builder_agent.py
+++ b/agents/implementation/prototype_builder_agent.py
@@ -18,6 +18,7 @@ from agents.implementation.helpers import dump_model, load_prompt_text, make_lab
 
 SUPPORTED_TARGET_FRAMEWORKS = {"streamlit"}
 KNOWN_UNSUPPORTED_TARGET_FRAMEWORKS = {"react", "fastapi", "nextjs"}
+KNOWN_TARGET_FRAMEWORKS = SUPPORTED_TARGET_FRAMEWORKS | KNOWN_UNSUPPORTED_TARGET_FRAMEWORKS
 
 
 def run_prototype_builder_agent(
@@ -33,10 +34,7 @@ def run_prototype_builder_agent(
     service_name = spec.service_name or input_model.spec_intake_output.service_summary.split(" ")[0]
     target_framework = _normalize_target_framework(spec.target_framework)
     if target_framework not in SUPPORTED_TARGET_FRAMEWORKS:
-        unsupported_reason = (
-            f"target_framework '{target_framework}' is not supported yet. "
-            "Currently supported: streamlit"
-        )
+        unsupported_reason = _build_unsupported_reason(target_framework)
         return PrototypeBuilderOutput(
             agent=make_label(
                 "Prototype Builder Agent",
@@ -126,9 +124,21 @@ def _build_app_source(input_model: PrototypeBuilderInput) -> str:
 
 def _normalize_target_framework(value: str) -> str:
     normalized = (value or "streamlit").strip().lower()
-    if normalized in KNOWN_UNSUPPORTED_TARGET_FRAMEWORKS:
-        return normalized
     return normalized or "streamlit"
+
+
+def _build_unsupported_reason(target_framework: str) -> str:
+    if target_framework in KNOWN_UNSUPPORTED_TARGET_FRAMEWORKS:
+        return (
+            f"target_framework '{target_framework}' is not supported yet. "
+            "Currently supported: streamlit"
+        )
+
+    known_values = ", ".join(sorted(KNOWN_TARGET_FRAMEWORKS))
+    return (
+        f"target_framework '{target_framework}' is not recognized. "
+        f"Known values: {known_values}."
+    )
 
 
 def _normalize_grade_thresholds(

--- a/agents/implementation/prototype_builder_agent.py
+++ b/agents/implementation/prototype_builder_agent.py
@@ -1,4 +1,4 @@
-"""Prototype builder agent for generating the Streamlit MVP application files."""
+"""Prototype builder agent for generating MVP application files."""
 
 from __future__ import annotations
 
@@ -16,6 +16,10 @@ from schemas.implementation.prototype_builder import (
 from agents.implementation.helpers import dump_model, load_prompt_text, make_label
 
 
+SUPPORTED_TARGET_FRAMEWORKS = {"streamlit"}
+KNOWN_UNSUPPORTED_TARGET_FRAMEWORKS = {"react", "fastapi", "nextjs"}
+
+
 def run_prototype_builder_agent(
     input_model: PrototypeBuilderInput,
     llm_client: LLMClient,
@@ -27,6 +31,29 @@ def run_prototype_builder_agent(
 
     spec = input_model.implementation_spec
     service_name = spec.service_name or input_model.spec_intake_output.service_summary.split(" ")[0]
+    target_framework = _normalize_target_framework(spec.target_framework)
+    if target_framework not in SUPPORTED_TARGET_FRAMEWORKS:
+        unsupported_reason = (
+            f"target_framework '{target_framework}' is not supported yet. "
+            "Currently supported: streamlit"
+        )
+        return PrototypeBuilderOutput(
+            agent=make_label(
+                "Prototype Builder Agent",
+                "MVP 서비스 코드 생성 Agent",
+            ),
+            service_name=service_name or "교육 서비스 MVP",
+            target_framework=target_framework,
+            is_supported=False,
+            unsupported_reason=unsupported_reason,
+            app_entrypoint="",
+            generated_files=[],
+            runtime_notes=[unsupported_reason],
+            integration_notes=[
+                "React/FastAPI/Next.js 생성은 후속 이슈에서 별도 Builder로 확장한다.",
+            ],
+        )
+
     content_filename = build_content_filename(service_name)
     app_source = _build_app_source(input_model)
     runtime_notes = [
@@ -51,6 +78,9 @@ def run_prototype_builder_agent(
             "MVP 서비스 코드 생성 Agent",
         ),
         service_name=service_name or "교육 서비스 MVP",
+        target_framework=target_framework,
+        is_supported=True,
+        unsupported_reason="",
         app_entrypoint="app.py",
         generated_files=[
             GeneratedFile(
@@ -92,6 +122,13 @@ def _build_app_source(input_model: PrototypeBuilderInput) -> str:
         service_name=service_name,
         content_filename=content_filename,
     )
+
+
+def _normalize_target_framework(value: str) -> str:
+    normalized = (value or "streamlit").strip().lower()
+    if normalized in KNOWN_UNSUPPORTED_TARGET_FRAMEWORKS:
+        return normalized
+    return normalized or "streamlit"
 
 
 def _normalize_grade_thresholds(

--- a/docs/implementation_decisions.md
+++ b/docs/implementation_decisions.md
@@ -47,3 +47,11 @@
 - 결정: 콘텐츠 Agent 후처리에서 `correct_choice` 보정, 최소 3개 선택지 보정, answer/explanation/learning point 매핑 보정을 수행한 뒤 계약 검증을 실행한다.
 - 이유: 이번 단계는 교육 콘텐츠 자동 생성의 완전한 미세 품질보다, 8문항 구조와 MVP 실행 가능성을 검증하는 것이 더 중요하기 때문이다.
 - 영향 범위: `agents/implementation/content_interaction_agent.py`, live `quiz_contents.json` 안정성
+
+## 2026-04-28
+
+### 결정 8. `target_framework`는 Streamlit 우선, 미지원 프레임워크는 명시적 중단
+- 맥락: 후속 React/FastAPI/Next.js 확장을 위해 Prototype Builder가 어떤 프레임워크를 대상으로 생성해야 하는지 알아야 한다.
+- 결정: runtime 기준 필드는 `ImplementationSpec.target_framework`로 두고, 현재 지원값은 `streamlit`만 허용한다. 다른 값은 fallback 생성 없이 unsupported output/log를 남긴 뒤 local checks 전에 중단한다.
+- 이유: 미지원 프레임워크를 Streamlit으로 암묵 대체하면 실제 지원 범위를 오해할 수 있기 때문이다.
+- 영향 범위: `schemas/implementation/implementation_spec.py`, `schemas/planning_package/package.py`, `agents/implementation/prototype_builder_agent.py`, `orchestrator/pipeline.py`

--- a/loaders/planning_package_loader.py
+++ b/loaders/planning_package_loader.py
@@ -159,6 +159,7 @@ def planning_package_to_implementation_spec(
     return ImplementationSpec(
         source_path=str(package_dir),
         service_name=package.service_meta.service_name,
+        target_framework=package.service_meta.target_framework or "streamlit",
         service_purpose=package.service_meta.purpose,
         target_users=target_users,
         learning_goals=package.evaluation_spec.rubric_criteria,

--- a/orchestrator/pipeline.py
+++ b/orchestrator/pipeline.py
@@ -116,6 +116,15 @@ class ImplementationPipeline:
             self.output_dir / "prototype_builder_output.json",
             prototype_builder_output,
         )
+        if not prototype_builder_output.is_supported:
+            return self._finish_unsupported_framework(
+                spec=spec,
+                spec_intake_output=spec_intake_output,
+                requirement_mapping_output=requirement_mapping_output,
+                content_interaction_output=content_interaction_output,
+                prototype_builder_output=prototype_builder_output,
+            )
+
         self._materialize_generated_files(prototype_builder_output.generated_files)
 
         local_checks = self._run_local_checks()
@@ -208,6 +217,9 @@ class ImplementationPipeline:
         content_filename: str,
     ) -> None:
         output.service_name = service_name
+        if not output.is_supported:
+            return
+
         output.runtime_notes = _dedupe_preserve_order(
             [
                 *output.runtime_notes,
@@ -226,6 +238,41 @@ class ImplementationPipeline:
                 generated_file.description = (
                     f"{service_name} 콘텐츠를 읽는 self-contained Streamlit MVP app."
                 )
+
+    def _finish_unsupported_framework(
+        self,
+        *,
+        spec: ImplementationSpec,
+        spec_intake_output,
+        requirement_mapping_output,
+        content_interaction_output,
+        prototype_builder_output,
+    ) -> dict[str, SchemaModel]:
+        reason = (
+            prototype_builder_output.unsupported_reason
+            or "Requested target_framework is not supported yet."
+        )
+        self._log(
+            "[UNSUPPORTED] "
+            f"target_framework={prototype_builder_output.target_framework}: {reason}"
+        )
+        self._write_execution_log()
+        self._write_unsupported_change_log(prototype_builder_output)
+        self._write_unsupported_qa_report(prototype_builder_output)
+        self._write_unsupported_final_summary(
+            spec=spec,
+            service_summary=spec_intake_output.service_summary,
+            implementation_targets=requirement_mapping_output.implementation_targets,
+            content_output=content_interaction_output,
+            prototype_builder_output=prototype_builder_output,
+        )
+        return {
+            "input_intake_result": self.input_intake_result,
+            "spec_intake_output": spec_intake_output,
+            "requirement_mapping_output": requirement_mapping_output,
+            "quiz_contents": content_interaction_output,
+            "prototype_builder_output": prototype_builder_output,
+        }
 
     def _materialize_generated_files(self, generated_files) -> None:
         for generated_file in generated_files:
@@ -366,6 +413,90 @@ class ImplementationPipeline:
         else:
             lines.extend(f"- {entry}" for entry in entries)
         (self.output_dir / "change_log.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    def _write_unsupported_change_log(self, prototype_builder_output) -> None:
+        lines = [
+            "# Change Log",
+            "",
+            (
+                "- Prototype Builder stopped before materialization because "
+                f"target_framework={prototype_builder_output.target_framework} is unsupported."
+            ),
+            f"- Reason: {prototype_builder_output.unsupported_reason}",
+            "- Local checks, Run Test And Fix, and QA Alignment stages were not executed.",
+        ]
+        (self.output_dir / "change_log.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    def _write_unsupported_qa_report(self, prototype_builder_output) -> None:
+        lines = [
+            "# QA Report",
+            "",
+            "- Alignment status: UNSUPPORTED",
+        ]
+        if self.input_intake_result is not None:
+            lines.extend(
+                [
+                    "",
+                    "## Input Intake",
+                    f"- Status: {self.input_intake_result.status.value}",
+                    f"- Auto fixes: {len(self.input_intake_result.auto_fixes)}",
+                    f"- Planning review items: {len(self.input_intake_result.planning_review_items)}",
+                    f"- Issues: {len(self.input_intake_result.issues)}",
+                ]
+            )
+        lines.extend(
+            [
+                "",
+                "## Unsupported Framework",
+                f"- target_framework: {prototype_builder_output.target_framework}",
+                f"- reason: {prototype_builder_output.unsupported_reason}",
+                "- local checks: NOT RUN",
+            ]
+        )
+        (self.output_dir / "qa_report.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+    def _write_unsupported_final_summary(
+        self,
+        *,
+        spec: ImplementationSpec,
+        service_summary: str,
+        implementation_targets: list[str],
+        content_output,
+        prototype_builder_output,
+    ) -> None:
+        lines = [
+            "# Final Summary",
+            "",
+            "## 서비스 요약",
+            f"- {service_summary}",
+            "",
+            "## Framework 결과",
+            f"- target_framework: {prototype_builder_output.target_framework}",
+            "- 지원 여부: UNSUPPORTED",
+            f"- 이유: {prototype_builder_output.unsupported_reason}",
+            "- app.py materialize: NOT RUN",
+            "- local checks: NOT RUN",
+        ]
+        if self.input_intake_result is not None:
+            lines.extend(
+                [
+                    "",
+                    "## Input Intake 결과",
+                    f"- 상태: {self.input_intake_result.status.value}",
+                    f"- target_framework: {self.input_intake_result.runtime_config.target_framework if self.input_intake_result.runtime_config else spec.target_framework}",
+                ]
+            )
+        lines.extend(["", "## 구현 요구사항 요약"])
+        lines.extend(f"- {target}" for target in implementation_targets)
+        lines.extend(
+            [
+                "",
+                "## 콘텐츠 생성 요약",
+                f"- 퀴즈 유형 수: {len(content_output.quiz_types)}",
+                f"- 총 문제 수: {len(content_output.items)}",
+            ]
+        )
+        (self.output_dir / "final_summary.md").write_text("\n".join(lines) + "\n", encoding="utf-8")
 
     def _write_qa_report(self, qa_output) -> None:
         lines = [

--- a/outputs/change_log.md
+++ b/outputs/change_log.md
@@ -2,4 +2,4 @@
 
 - Prototype Builder Agent는 live 실행 안정성을 위해 검증된 Streamlit 템플릿을 사용하도록 정규화되었다.
 - QA & Alignment Agent는 현재 단계에서 deterministic summary를 생성한다.
-- #12 semantic validator 결과: expected_total=3, actual_total=3, configured_content_types=2, content_types_valid=True, learning_dimension_valid=True, semantic_validator_passed=True, regeneration_count=1, streamlit_smoke=PASS, package_pytest=PASS.
+- #12 semantic validator 결과: expected_total=3, actual_total=3, configured_content_types=2, content_types_valid=True, learning_dimension_valid=True, semantic_validator_passed=True, regeneration_count=0, streamlit_smoke=PASS, package_pytest=PASS.

--- a/outputs/final_summary.md
+++ b/outputs/final_summary.md
@@ -1,7 +1,7 @@
 # Final Summary
 
 ## 서비스 요약
-- 중학생 대상 AI 질문 능력 향상 서비스. 메타인지 결핍과 언어적 구체화 능력 부족을 해결하기 위해 주제/상황/원하는 답의 형태를 포함한 질문 작성 훈련을 제공. 3개 세션(5~10분)으로 구성되며, 점수 누적 시스템과 쉬운 표현을 통해 성취감을 유도.
+- 중학생 대상 AI 질문 능력 향상 훈련 서비스. 메타인지 결핍과 언어적 구체화 능력 부족을 해결하기 위해 주제/상황/원하는 답 형태를 포함한 질문 작성 훈련을 제공. Streamlit 기반 구현으로 3개 세션(질문 작성 → 피드백 → 개선) 반복 구조. 평가보다 성장 강조, 짧은 성취 경험, 중학생 친화적 표현 사용.
 
 ## Input Intake 결과
 - 상태: AUTO_FIXED
@@ -11,14 +11,15 @@
 - 생성 단위 분포: {'multiple_choice': 1, 'question_improvement': 2}
 
 ## 구현 요구사항 요약
-- 중학생 대상 메타인지 및 질문 구체화 능력 훈련 제공
-- 주제/상황/원하는 답의 형태 3요소를 포함한 질문 작성 기능 구현
-- 다중 선택(multiple_choice) 및 질문 개선(question_improvement) 핵심 기능 포함
-- 3개 세션(SESSION_START → QUEST_N_ACTIVE → QUEST_N_FEEDBACK) 상태 전이 구조 구현
-- 점수 누적 시스템(감소 없음) 및 등급 갱신 메커니즘 적용
-- 중학생 눈높이에 맞춘 쉬운 표현 사용(피드백/안내/평가)
-- API 엔드포인트: /api/session/start, /api/quest/submit, /api/session/result
-- 학습 목표: 구체성, 맥락성, 목적성 달성
+- 중학생 대상 AI 질문 능력 향상 훈련 시스템 구현
+- 주제/상황/원하는 답 형태 3요소 포함 질문 작성 기능
+- 3개 세션(질문 작성 → 피드백 → 개선) 반복 구조
+- 다중 선택 및 질문 개선 핵심 기능 구현
+- 상태 전이 로직 구현 (SESSION_START → QUEST_N_ACTIVE → QUEST_N_FEEDBACK → SESSION_COMPLETED)
+- 점수 누적 시스템 및 등급 갱신 메커니즘 구현
+- 중학생 친화적 표현 사용
+- 5-10분 단위 즉각적 성취감 제공 설계
+- 답을 바로 주지 않고 질문 개선 유도
 
 ## 콘텐츠 생성 요약
 - 퀴즈 유형 수: 2
@@ -31,7 +32,7 @@
 - configured content type 수(2) 일치 여부: PASS
 - learning_dimension 허용값 여부: PASS
 - semantic validator 통과 여부: PASS
-- 재생성 발생 여부: YES
+- 재생성 발생 여부: NO
 - app.py Streamlit smoke test 여부: PASS
 - package pytest.py 통과 여부: PASS
 
@@ -39,6 +40,6 @@
 - 교육 서비스 구현팀 6-Agent 파이프라인이 실행되었다.
 - 2개 content type, 총 3문항이 생성되었다.
 - 세션 구성: multiple_choice 1 + question_improvement 2.
-- #12 검증 결과: semantic validator=PASS, 재생성=1건.
+- #12 검증 결과: semantic validator=PASS, 재생성=없음.
 - #20 실행 검증 결과: package_pytest=PASS, streamlit_smoke=PASS.
 - Streamlit MVP, 실행 로그, QA 결과가 함께 정리되었다.

--- a/outputs/input_intake_report.json
+++ b/outputs/input_intake_report.json
@@ -3,6 +3,7 @@
   "planning_package": {
     "service_meta": {
       "service_name": "question_quest",
+      "target_framework": "streamlit",
       "target_user": "중학생",
       "purpose": "학생들이 AI에게 질문을 잘 하지 못하는 현상을 단순한 \"기능 사용법 부족\"이 아니라 학습 결핍 관점에서 재정의한다. **막연한 질문 = 메타인지 결핍 + 언어적 구체화 능력 부족** 학생은 자신이 무엇을 알고 무엇을 모르는지 스스로 점검하지 못하고(메타인지 결핍), 그 모르는 지점을 언어로 옮겨내는 훈련도 부족하다(구체화 능력 부족). 따라서 이 서비스는 \"AI 사용법 강의\"가 아니라 **자기 질문을 다듬는 반복적 훈련 경험**을 제공해야 한다. 중학생이 AI에게 질문할 때, **주제**·**상황**·**원하는 답의 형태**를 포함한 질문을 스스로 작성할 수 있다. **주체**: 중학생 **조건**: AI에게 질문하는 상황에서 **관찰 가능한 행동**: 주제 / 상황 / 원하는 답의 형태 세 요소를 포함한 질문을 스스로 작성",
       "version": "v0"
@@ -141,6 +142,7 @@
   "implementation_spec": {
     "source_path": "inputs/mock_planning_outputs/question_quest_v0",
     "service_name": "question_quest",
+    "target_framework": "streamlit",
     "team_identity": "교육 서비스 구현 전문 AI Agent 팀",
     "service_purpose": "학생들이 AI에게 질문을 잘 하지 못하는 현상을 단순한 \"기능 사용법 부족\"이 아니라 학습 결핍 관점에서 재정의한다. **막연한 질문 = 메타인지 결핍 + 언어적 구체화 능력 부족** 학생은 자신이 무엇을 알고 무엇을 모르는지 스스로 점검하지 못하고(메타인지 결핍), 그 모르는 지점을 언어로 옮겨내는 훈련도 부족하다(구체화 능력 부족). 따라서 이 서비스는 \"AI 사용법 강의\"가 아니라 **자기 질문을 다듬는 반복적 훈련 경험**을 제공해야 한다. 중학생이 AI에게 질문할 때, **주제**·**상황**·**원하는 답의 형태**를 포함한 질문을 스스로 작성할 수 있다. **주체**: 중학생 **조건**: AI에게 질문하는 상황에서 **관찰 가능한 행동**: 주제 / 상황 / 원하는 답의 형태 세 요소를 포함한 질문을 스스로 작성",
     "target_users": [
@@ -237,7 +239,7 @@
       "field_path": "runtime_config.target_framework",
       "before": null,
       "after": "streamlit",
-      "reason": "target_framework 누락 시 기본 실행 프레임워크를 streamlit으로 설정했다."
+      "reason": "ImplementationSpec 기준 target_framework 실행 값을 기록했다."
     },
     {
       "field_path": "runtime_config.content_output_filename",
@@ -270,7 +272,7 @@
   "quality_judgement": {
     "auto_fixable_functional_gaps": [
       "service_slug 실행 값을 생성했다.",
-      "target_framework 누락 시 기본 실행 프레임워크를 streamlit으로 설정했다.",
+      "ImplementationSpec 기준 target_framework 실행 값을 기록했다.",
       "service_slug 기반 콘텐츠 출력 파일명을 생성했다.",
       "입력 package 경로를 절대 경로로 정규화했다.",
       "생성 단위 수를 content type별 분포로 추론했다."

--- a/outputs/prototype_builder_output.json
+++ b/outputs/prototype_builder_output.json
@@ -4,6 +4,9 @@
     "korean_name": "MVP 서비스 코드 생성 Agent"
   },
   "service_name": "question_quest",
+  "target_framework": "streamlit",
+  "is_supported": true,
+  "unsupported_reason": "",
   "app_entrypoint": "app.py",
   "generated_files": [
     {

--- a/outputs/qa_alignment_output.json
+++ b/outputs/qa_alignment_output.json
@@ -10,7 +10,7 @@
     "configured content type 수(2) 일치 여부: PASS",
     "learning_dimension 허용값 여부: PASS",
     "semantic validator 통과 여부: PASS",
-    "재생성 발생 여부: YES",
+    "재생성 발생 여부: NO",
     "app.py Streamlit smoke test 여부: PASS",
     "package pytest.py 통과 여부: PASS",
     "app.py가 서비스별 콘텐츠 파일을 읽도록 생성되었는지 확인",
@@ -20,13 +20,13 @@
   "change_log_entries": [
     "Prototype Builder Agent는 live 실행 안정성을 위해 검증된 Streamlit 템플릿을 사용하도록 정규화되었다.",
     "QA & Alignment Agent는 현재 단계에서 deterministic summary를 생성한다.",
-    "#12 semantic validator 결과: expected_total=3, actual_total=3, configured_content_types=2, content_types_valid=True, learning_dimension_valid=True, semantic_validator_passed=True, regeneration_count=1, streamlit_smoke=PASS, package_pytest=PASS."
+    "#12 semantic validator 결과: expected_total=3, actual_total=3, configured_content_types=2, content_types_valid=True, learning_dimension_valid=True, semantic_validator_passed=True, regeneration_count=0, streamlit_smoke=PASS, package_pytest=PASS."
   ],
   "final_summary_points": [
     "교육 서비스 구현팀 6-Agent 파이프라인이 실행되었다.",
     "2개 content type, 총 3문항이 생성되었다.",
     "세션 구성: multiple_choice 1 + question_improvement 2.",
-    "#12 검증 결과: semantic validator=PASS, 재생성=1건.",
+    "#12 검증 결과: semantic validator=PASS, 재생성=없음.",
     "#20 실행 검증 결과: package_pytest=PASS, streamlit_smoke=PASS.",
     "Streamlit MVP, 실행 로그, QA 결과가 함께 정리되었다."
   ]

--- a/outputs/qa_report.md
+++ b/outputs/qa_report.md
@@ -15,7 +15,7 @@
 - configured content type 수(2) 일치 여부: PASS
 - learning_dimension 허용값 여부: PASS
 - semantic validator 통과 여부: PASS
-- 재생성 발생 여부: YES
+- 재생성 발생 여부: NO
 - app.py Streamlit smoke test 여부: PASS
 - package pytest.py 통과 여부: PASS
 - app.py가 서비스별 콘텐츠 파일을 읽도록 생성되었는지 확인

--- a/outputs/question_quest_contents.json
+++ b/outputs/question_quest_contents.json
@@ -3,7 +3,7 @@
     "english_name": "Content & Interaction Agent",
     "korean_name": "교육 콘텐츠·상호작용 생성 Agent"
   },
-  "service_summary": "중학생 대상 메타인지 및 질문 구체화 능력 훈련 서비스. 주제/상황/원하는 답의 형태 3요소를 포함한 질문 작성 기능을 통해 구체성, 맥락성, 목적성 학습 목표를 달성합니다.",
+  "service_summary": "중학생 대상 AI 질문 능력 향상 훈련 서비스. 메타인지 결핍과 언어적 구체화 능력 부족을 해결하기 위해 주제/상황/원하는 답 형태를 포함한 질문 작성 훈련을 제공. Streamlit 기반 구현으로 3개 세션(질문 작성 → 피드백 → 개선) 반복 구조. 평가보다 성장 강조, 짧은 성취 경험, 중학생 친화적 표현 사용.",
   "quiz_types": [
     "multiple_choice",
     "question_improvement"
@@ -14,79 +14,77 @@
       "quiz_type": "multiple_choice",
       "difficulty": "intro",
       "learning_dimension": "구체성",
-      "title": "질문 구체화 연습",
+      "title": "질문 구체성 평가",
       "topic_context": "구체성",
-      "original_question": "다음 중 '과학 실험 결과를 어떻게 개선할 수 있을까?'라는 질문을 더 구체적으로 바꾼 예시는 무엇인가요?",
-      "question": "다음 중 '과학 실험 결과를 어떻게 개선할 수 있을까?'라는 질문을 더 구체적으로 바꾼 예시는 무엇인가요?",
+      "original_question": "다음 중 가장 구체적인 질문은 무엇인가요?",
+      "question": "다음 중 가장 구체적인 질문은 무엇인가요?",
       "choices": [
-        "실험 결과를 더 정확하게 측정하는 방법은 무엇인가요?",
-        "실험에서 어떤 변수를 조절해야 할까요?",
-        "과학 실험이 왜 중요한가요?",
-        "실험 결과를 어떻게 발표해야 할까요?"
+        "과학 실험에 대해 어떻게 생각하나요?",
+        "학교 과학 실험 중 가장 기억에 남는 실험은 무엇인가요?",
+        "학교 과학 실험 중 가장 기억에 남는 실험은 무엇이었고, 그 이유는 무엇인가요?"
       ],
-      "correct_choice": "실험 결과를 더 정확하게 측정하는 방법은 무엇인가요?",
-      "explanation": "원래 질문은 너무 광범위하지만, 정답 선택지는 '정확하게 측정'이라는 구체적인 방법을 묻고 있어 구체성 학습 목표에 부합합니다.",
-      "learning_point": "질문은 가능한 한 구체적인 행동이나 방법을 포함해야 합니다."
+      "correct_choice": "학교 과학 실험 중 가장 기억에 남는 실험은 무엇이었고, 그 이유는 무엇인가요?",
+      "explanation": "세 번째 질문은 '어떤 실험'과 '이유'라는 두 가지 구체성을 모두 포함하고 있어 가장 구체적입니다.",
+      "learning_point": "좋은 질문은 '무엇'과 '왜'를 함께 묻는 구체성을 가져야 합니다."
     },
     {
       "item_id": "Q002",
       "quiz_type": "question_improvement",
       "difficulty": "main",
-      "learning_dimension": "구체성",
-      "title": "맥락 반영 질문 개선",
+      "learning_dimension": "맥락성",
+      "title": "질문 맥락성 개선",
       "topic_context": "맥락성",
-      "original_question": "역사 시험에서 좋은 점수를 받으려면 어떻게 해야 하나요?",
-      "question": "다음 질문을 더 맥락이 명확하도록 수정하세요: '역사 시험에서 좋은 점수를 받으려면 어떻게 해야 하나요?'",
+      "original_question": "다음 질문을 더 맥락적으로 개선해보세요: '환경 보호에 대해 어떻게 생각하나요?'",
+      "question": "다음 질문을 더 맥락적으로 개선해보세요: '환경 보호에 대해 어떻게 생각하나요?'",
       "choices": [
-        "시험 범위를 어떻게 효율적으로 공부할 수 있을까요?",
-        "역사 시험 문제를 빨리 풀 수 있는 방법은 무엇인가요?",
-        "역사 시험 점수를 높이기 위해 어떤 자료를 활용해야 할까요?",
-        "시험 전날 어떻게 준비해야 할까요?"
+        "학교 급식 잔반 문제를 줄이기 위한 방법은 무엇일까요?",
+        "플라스틱 사용을 줄이기 위해 우리 반에서 실천할 수 있는 방법은 무엇인가요?",
+        "환경 보호를 위해 가정에서 할 수 있는 가장 쉬운 일은 무엇인가요?"
       ],
-      "correct_choice": "시험 범위를 어떻게 효율적으로 공부할 수 있을까요?",
-      "explanation": "정답 선택지는 '시험 범위'라는 구체적인 맥락을 포함하며, 일반적인 시험 준비보다 더 명확한 상황을 제시합니다.",
-      "learning_point": "질문은 특정 상황이나 배경을 반영해야 더 의미 있는 답변을 얻을 수 있습니다."
+      "correct_choice": "플라스틱 사용을 줄이기 위해 우리 반에서 실천할 수 있는 방법은 무엇인가요?",
+      "explanation": "개선된 질문은 '우리 반'이라는 구체적인 상황과 '플라스틱 사용'이라는 명확한 대상을 포함해 맥락성이 강화되었습니다.",
+      "learning_point": "좋은 질문은 특정 상황과 대상을 명시해 맥락성을 높여야 합니다."
     },
     {
       "item_id": "Q003",
       "quiz_type": "question_improvement",
       "difficulty": "main",
-      "learning_dimension": "구체성",
-      "title": "질문 목적 명확화",
+      "learning_dimension": "목적성",
+      "title": "질문 목적성 강화",
       "topic_context": "목적성",
-      "original_question": "수학 문제를 잘 풀려면 어떻게 해야 할까?",
-      "question": "다음 중 원래 질문의 목적('수학 문제 해결 능력 향상')을 가장 잘 반영하면서 더 구체화된 질문은 무엇인가요?",
+      "original_question": "다음 질문을 더 목적성 있게 개선해보세요: '역사 공부를 잘 하려면 어떻게 해야 하나요?'",
+      "question": "다음 질문을 더 목적성 있게 개선해보세요: '역사 공부를 잘 하려면 어떻게 해야 하나요?'",
       "choices": [
-        "수학 문제 풀이 속도를 높이는 방법은 무엇인가요?",
-        "수학 개념을 더 잘 이해하려면 어떻게 해야 할까요?",
-        "수학 시험 불안을 줄이는 방법은 무엇인가요?",
-        "수학 문제를 풀 때 실수를 줄이는 방법은 무엇인가요?"
+        "역사 시험 점수를 높이기 위해 매일 10분씩 복습할 주제는 무엇인가요?",
+        "역사 수업에서 가장 이해하기 어려운 부분은 무엇이고, 그 이유는 무엇인가요?",
+        "역사 공부 시간을 효율적으로 관리하기 위한 방법은 무엇인가요?"
       ],
-      "correct_choice": "수학 개념을 더 잘 이해하려면 어떻게 해야 할까요?",
-      "explanation": "정답 선택지는 원래 질문의 핵심 목적인 '문제 해결 능력 향상'과 직접적으로 연결되며, '개념 이해'라는 구체적인 학습 목표를 제시합니다. 다른 선택지들은 속도, 불안, 실수 감소 등 부차적인 요소에 집중하고 있습니다.",
-      "learning_point": "질문은 명확한 목적을 가져야 효과적인 답변을 이끌어낼 수 있습니다. '왜 이 질문을 하는가?'를 고민하면 더 좋은 질문을 만들 수 있어요!"
+      "correct_choice": "역사 시험 점수를 높이기 위해 매일 10분씩 복습할 주제는 무엇인가요?",
+      "explanation": "개선된 질문은 '시험 점수 향상'이라는 명확한 목적과 '매일 10분 복습'이라는 실행 가능한 방법을 제시해 목적성이 강화되었습니다.",
+      "learning_point": "좋은 질문은 달성하고자 하는 구체적인 목적을 명시해야 합니다."
     }
   ],
   "answer_key": {
-    "Q001": "실험 결과를 더 정확하게 측정하는 방법은 무엇인가요?",
-    "Q002": "시험 범위를 어떻게 효율적으로 공부할 수 있을까요?",
-    "Q003": "수학 개념을 더 잘 이해하려면 어떻게 해야 할까요?"
+    "Q001": "학교 과학 실험 중 가장 기억에 남는 실험은 무엇이었고, 그 이유는 무엇인가요?",
+    "Q002": "플라스틱 사용을 줄이기 위해 우리 반에서 실천할 수 있는 방법은 무엇인가요?",
+    "Q003": "역사 시험 점수를 높이기 위해 매일 10분씩 복습할 주제는 무엇인가요?"
   },
   "explanations": {
-    "Q001": "원래 질문은 너무 광범위하지만, 정답 선택지는 '정확하게 측정'이라는 구체적인 방법을 묻고 있어 구체성 학습 목표에 부합합니다.",
-    "Q002": "정답 선택지는 '시험 범위'라는 구체적인 맥락을 포함하며, 일반적인 시험 준비보다 더 명확한 상황을 제시합니다.",
-    "Q003": "정답 선택지는 원래 질문의 핵심 목적인 '문제 해결 능력 향상'과 직접적으로 연결되며, '개념 이해'라는 구체적인 학습 목표를 제시합니다. 다른 선택지들은 속도, 불안, 실수 감소 등 부차적인 요소에 집중하고 있습니다."
+    "Q001": "세 번째 질문은 '어떤 실험'과 '이유'라는 두 가지 구체성을 모두 포함하고 있어 가장 구체적입니다.",
+    "Q002": "개선된 질문은 '우리 반'이라는 구체적인 상황과 '플라스틱 사용'이라는 명확한 대상을 포함해 맥락성이 강화되었습니다.",
+    "Q003": "개선된 질문은 '시험 점수 향상'이라는 명확한 목적과 '매일 10분 복습'이라는 실행 가능한 방법을 제시해 목적성이 강화되었습니다."
   },
   "learning_points": {
-    "Q001": "질문은 가능한 한 구체적인 행동이나 방법을 포함해야 합니다.",
-    "Q002": "질문은 특정 상황이나 배경을 반영해야 더 의미 있는 답변을 얻을 수 있습니다.",
-    "Q003": "질문은 명확한 목적을 가져야 효과적인 답변을 이끌어낼 수 있습니다. '왜 이 질문을 하는가?'를 고민하면 더 좋은 질문을 만들 수 있어요!"
+    "Q001": "좋은 질문은 '무엇'과 '왜'를 함께 묻는 구체성을 가져야 합니다.",
+    "Q002": "좋은 질문은 특정 상황과 대상을 명시해 맥락성을 높여야 합니다.",
+    "Q003": "좋은 질문은 달성하고자 하는 구체적인 목적을 명시해야 합니다."
   },
   "interaction_notes": [
-    "학습자는 각 문항을 통해 질문의 구체성, 맥락성, 목적성을 체계적으로 훈련합니다.",
-    "multiple_choice 유형에서는 가장 적합한 개선 예시를 선택하며, question_improvement 유형에서는 직접 질문을 수정합니다.",
-    "피드백 단계에서는 정답과 해설을 통해 자신의 선택이나 수정 내용을 점검합니다.",
-    "학습 포인트를 통해 각 문항이 강조하는 질문 작성 기술을 명확히 이해합니다."
+    "학생은 먼저 다중 선택 문제를 통해 질문 구체성 평가 방법을 학습합니다.",
+    "다음으로 맥락성 개선 문제를 풀며 원본 질문을 개선하는 연습을 합니다.",
+    "마지막으로 목적성 강화 문제를 통해 질문의 목적을 명확히 하는 훈련을 합니다.",
+    "모든 문제는 5분 이내에 완료할 수 있도록 설계되어 즉각적인 성취감을 제공합니다.",
+    "피드백 단계에서는 정답뿐만 아니라 개선 포인트와 학습 포인트를 함께 제시합니다."
   ],
   "semantic_validation": {
     "total_items": 3,
@@ -95,16 +93,16 @@
       "question_improvement": 2
     },
     "learning_dimension_counts": {
-      "구체성": 3
+      "구체성": 1,
+      "맥락성": 1,
+      "목적성": 1
     },
     "learning_dimension_values_valid": true,
     "quiz_type_distribution_valid": true,
     "semantic_validator_passed": true,
-    "regeneration_requested": true,
-    "regeneration_count": 1,
-    "regenerated_item_ids": [
-      "Q003"
-    ],
+    "regeneration_requested": false,
+    "regeneration_count": 0,
+    "regenerated_item_ids": [],
     "item_results": [
       {
         "item_id": "Q001",
@@ -127,31 +125,28 @@
         "expected_quiz_type": "question_improvement",
         "quiz_type_match": true,
         "current_learning_dimension": "맥락성",
-        "expected_learning_dimension": "구체성",
-        "learning_dimension_match": false,
-        "applied_label_corrections": [
-          "learning_dimension: 맥락성 -> 구체성"
-        ],
+        "expected_learning_dimension": "맥락성",
+        "learning_dimension_match": true,
+        "applied_label_corrections": [],
         "requires_regeneration": false,
         "reasons": [
           "문항 quiz_type이 implementation_spec.core_features에 포함됩니다.",
-          "정답이나 질문이 대상/조건/세부 정보를 더 구체적으로 만듭니다."
+          "해설 또는 학습 포인트가 맥락성을 직접 설명합니다."
         ]
       },
       {
         "item_id": "Q003",
-        "current_quiz_type": "multiple_choice",
+        "current_quiz_type": "question_improvement",
         "expected_quiz_type": "question_improvement",
-        "quiz_type_match": false,
+        "quiz_type_match": true,
         "current_learning_dimension": "목적성",
-        "expected_learning_dimension": "구체성",
-        "learning_dimension_match": false,
+        "expected_learning_dimension": "목적성",
+        "learning_dimension_match": true,
         "applied_label_corrections": [],
-        "requires_regeneration": true,
+        "requires_regeneration": false,
         "reasons": [
           "문항 quiz_type이 implementation_spec.core_features에 포함됩니다.",
-          "정답이나 질문이 원하는 도움이나 답변 목적을 더 분명하게 만듭니다.",
-          "정답이나 질문이 대상/조건/세부 정보를 더 구체적으로 만듭니다."
+          "해설 또는 학습 포인트가 목적성을 직접 설명합니다."
         ]
       }
     ]

--- a/outputs/requirement_mapping_output.json
+++ b/outputs/requirement_mapping_output.json
@@ -4,66 +4,71 @@
     "korean_name": "구현 요구사항 정리 Agent"
   },
   "implementation_targets": [
-    "중학생 대상 메타인지 및 질문 구체화 능력 훈련 제공",
-    "주제/상황/원하는 답의 형태 3요소를 포함한 질문 작성 기능 구현",
-    "다중 선택(multiple_choice) 및 질문 개선(question_improvement) 핵심 기능 포함",
-    "3개 세션(SESSION_START → QUEST_N_ACTIVE → QUEST_N_FEEDBACK) 상태 전이 구조 구현",
-    "점수 누적 시스템(감소 없음) 및 등급 갱신 메커니즘 적용",
-    "중학생 눈높이에 맞춘 쉬운 표현 사용(피드백/안내/평가)",
-    "API 엔드포인트: /api/session/start, /api/quest/submit, /api/session/result",
-    "학습 목표: 구체성, 맥락성, 목적성 달성"
+    "중학생 대상 AI 질문 능력 향상 훈련 시스템 구현",
+    "주제/상황/원하는 답 형태 3요소 포함 질문 작성 기능",
+    "3개 세션(질문 작성 → 피드백 → 개선) 반복 구조",
+    "다중 선택 및 질문 개선 핵심 기능 구현",
+    "상태 전이 로직 구현 (SESSION_START → QUEST_N_ACTIVE → QUEST_N_FEEDBACK → SESSION_COMPLETED)",
+    "점수 누적 시스템 및 등급 갱신 메커니즘 구현",
+    "중학생 친화적 표현 사용",
+    "5-10분 단위 즉각적 성취감 제공 설계",
+    "답을 바로 주지 않고 질문 개선 유도"
   ],
   "file_plan": [
     {
       "path": "data_schema.json",
-      "purpose": "데이터 스키마 검증 및 API 요청/응답 구조 정의",
+      "purpose": "서비스 데이터 구조 및 유효성 검증 기준 정의",
       "producing_agent": "Spec Intake Agent"
     },
     {
       "path": "state_machine.md",
-      "purpose": "3개 세션 상태 전이 로직 및 전이 조건 문서화",
+      "purpose": "세션 상태 전이 로직 및 조건 명시",
       "producing_agent": "Spec Intake Agent"
     },
     {
       "path": "constitution.md",
-      "purpose": "점수 누적 규칙, 등급 갱신 메커니즘, 피드백 기준 명시",
+      "purpose": "점수 누적 규칙, 등급 갱신 조건, 중학생 친화적 표현 가이드라인 정의",
       "producing_agent": "Spec Intake Agent"
     },
     {
       "path": "prompt_spec.md",
-      "purpose": "프롬프트 출력 형식 및 중학생 친화적 표현 가이드라인 정의",
+      "purpose": "프롬프트 출력 형식 및 질문 개선 유도 메시지 템플릿 정의",
       "producing_agent": "Spec Intake Agent"
     },
     {
       "path": "interface_spec.md",
-      "purpose": "API 엔드포인트 응답 형식 및 오류 처리 규칙 명시",
+      "purpose": "API 응답 형식, 오류 처리, 데이터 변환 규칙 명시",
       "producing_agent": "Spec Intake Agent"
     }
   ],
   "quiz_generation_requirements": {
     "quiz_type_count": 2,
-    "items_per_type": 5,
-    "total_items": 10,
+    "items_per_type": 1,
+    "total_items": 2,
     "required_fields": [
-      "주제",
-      "상황",
-      "원하는 답의 형태",
-      "정답",
-      "피드백"
+      "topic",
+      "context",
+      "desired_answer_type",
+      "user_question",
+      "feedback_type",
+      "improved_question"
     ]
   },
   "app_constraints": [
-    "세션 상태 전이 시 데이터 손실 방지",
-    "점수 시스템은 감소 없이 누적만 허용",
-    "API 응답은 JSON 스키마 검증 필수",
-    "프롬프트 출력은 중학생 수준의 쉬운 표현 사용",
-    "피드백 메시지는 학습 목표(구체성, 맥락성, 목적성) 반영"
+    "Streamlit 기반 구현으로 3개 세션 반복 구조 필수",
+    "API 엔드포인트(/api/session/start, /api/quest/submit, /api/session/result) 구현 필수",
+    "점수 감소 없이 누적 시스템 구현",
+    "중학생 친화적 표현 사용(어려운 어휘 배제)",
+    "즉각적 성취감을 위한 5-10분 세션 설계",
+    "답을 바로 주지 않고 질문 개선 유도"
   ],
   "test_strategy": [
-    "data_schema.json으로 API 요청/응답 유효성 검증",
-    "state_machine.md 기반으로 상태 전이 테스트 케이스 실행",
-    "constitution.md 규칙에 따른 점수/등급 계산 검증",
-    "prompt_spec.md에 명시된 출력 형식 준수 여부 확인",
-    "interface_spec.md에 정의된 API 응답 구조 검증"
+    "data_schema.json에 정의된 데이터 스키마 검증",
+    "state_machine.md에 명시된 상태 전이 로직 검증",
+    "constitution.md에 정의된 점수·등급 규칙 검증",
+    "prompt_spec.md에 명시된 프롬프트 출력 형식 검증",
+    "interface_spec.md에 정의된 API 응답 형식 검증",
+    "다중 선택 및 질문 개선 기능 통합 테스트",
+    "세션 반복 구조 및 상태 전이 엔드투엔드 테스트"
   ]
 }

--- a/outputs/spec_intake_output.json
+++ b/outputs/spec_intake_output.json
@@ -4,24 +4,26 @@
     "korean_name": "구현 명세서 분석 Agent"
   },
   "team_identity": "교육 서비스 구현 전문 AI Agent 팀",
-  "service_summary": "중학생 대상 AI 질문 능력 향상 서비스. 메타인지 결핍과 언어적 구체화 능력 부족을 해결하기 위해 주제/상황/원하는 답의 형태를 포함한 질문 작성 훈련을 제공. 3개 세션(5~10분)으로 구성되며, 점수 누적 시스템과 쉬운 표현을 통해 성취감을 유도.",
+  "service_summary": "중학생 대상 AI 질문 능력 향상 훈련 서비스. 메타인지 결핍과 언어적 구체화 능력 부족을 해결하기 위해 주제/상황/원하는 답 형태를 포함한 질문 작성 훈련을 제공. Streamlit 기반 구현으로 3개 세션(질문 작성 → 피드백 → 개선) 반복 구조. 평가보다 성장 강조, 짧은 성취 경험, 중학생 친화적 표현 사용.",
   "normalized_requirements": [
-    "중학생 대상 메타인지 및 질문 구체화 능력 훈련 제공",
-    "주제/상황/원하는 답의 형태 3요소를 포함한 질문 작성 기능 구현",
-    "다중 선택(multiple_choice) 및 질문 개선(question_improvement) 핵심 기능 포함",
-    "3개 세션(SESSION_START → QUEST_N_ACTIVE → QUEST_N_FEEDBACK) 상태 전이 구조 구현",
-    "점수 누적 시스템(감소 없음) 및 등급 갱신 메커니즘 적용",
-    "중학생 눈높이에 맞춘 쉬운 표현 사용(피드백/안내/평가)",
-    "API 엔드포인트: /api/session/start, /api/quest/submit, /api/session/result",
-    "학습 목표: 구체성, 맥락성, 목적성 달성"
+    "중학생 대상 AI 질문 능력 향상 훈련 시스템 구현",
+    "주제/상황/원하는 답 형태 3요소 포함 질문 작성 기능",
+    "3개 세션(질문 작성 → 피드백 → 개선) 반복 구조",
+    "다중 선택(multiple_choice) 및 질문 개선(question_improvement) 핵심 기능",
+    "상태 전이 로직: SESSION_START → QUEST_N_ACTIVE → QUEST_N_FEEDBACK → SESSION_COMPLETED",
+    "점수 누적 시스템(감소 없음) 및 등급 갱신 메커니즘",
+    "중학생 친화적 표현 사용(어려운 어휘 배제)",
+    "즉각적 성취감 제공을 위한 5-10분 세션 설계",
+    "답을 바로 주지 않고 질문 개선 유도"
   ],
   "delivery_expectations": [
-    "S0, S1, S2, S3, S4, S5 산출물 생성",
-    "data_schema.json(데이터 스키마 검증)",
-    "state_machine.md(상태 전이 로직 검증)",
-    "constitution.md ⑦(점수·등급 규칙 검증)",
-    "prompt_spec.md(프롬프트 출력 형식 검증)",
-    "interface_spec.md(API 응답 형식 검증)"
+    "S0, S1, S2, S3, S4, S5 산출물",
+    "/api/session/start, /api/quest/submit, /api/session/result API 구현",
+    "data_schema.json(데이터 스키마)",
+    "state_machine.md(상태 전이 로직)",
+    "constitution.md ⑦(점수·등급 규칙)",
+    "prompt_spec.md(프롬프트 출력 형식)",
+    "interface_spec.md(API 응답 형식)"
   ],
   "acceptance_focus": [
     "데이터 스키마 검증",

--- a/prompts/implementation/prototype_builder.md
+++ b/prompts/implementation/prototype_builder.md
@@ -1,7 +1,8 @@
 당신은 Prototype Builder Agent / MVP 서비스 코드 생성 Agent다.
 
 목표:
-- 생성된 교육 콘텐츠를 바로 보여줄 수 있는 Streamlit MVP 파일을 만든다.
+- `target_framework`를 확인하고, 지원되는 프레임워크에 대해서만 MVP 파일을 만든다.
+- 현재 지원 프레임워크는 `streamlit`뿐이다.
 
 명세 요약:
 {spec_intake_output}
@@ -13,6 +14,7 @@
 {content_interaction_output}
 
 반드시 아래를 지켜라:
-- app은 `outputs/quiz_contents.json`을 읽어야 한다.
-- 사용자는 문제 풀이, 정답 확인, 해설과 학습 포인트 확인이 가능해야 한다.
-- generated_files에 반드시 `app.py`를 포함한다.
+- `target_framework == "streamlit"`이면 app은 서비스별 contents JSON 파일을 읽어야 한다.
+- `streamlit` 앱에서 사용자는 문제 풀이, 정답 확인, 해설과 학습 포인트 확인이 가능해야 한다.
+- `target_framework`가 `react`, `fastapi`, `nextjs` 등 미지원 값이면 앱 파일을 생성하지 말고 unsupported 이유를 명확히 남긴다.
+- 지원되는 경우에만 generated_files에 `app.py`를 포함한다.

--- a/schemas/implementation/implementation_spec.py
+++ b/schemas/implementation/implementation_spec.py
@@ -11,6 +11,10 @@ from schemas.implementation.common import SchemaModel
 class ImplementationSpec(SchemaModel):
     source_path: str = Field(description="Original spec file path.")
     service_name: str = Field(description="Name of the target education service.")
+    target_framework: str = Field(
+        default="streamlit",
+        description="Target application framework. Currently only streamlit is supported.",
+    )
     team_identity: str = Field(
         default="교육 서비스 구현 전문 AI Agent 팀",
         description="Identity of the implementation team.",
@@ -53,6 +57,7 @@ def parse_markdown_spec(path: Path) -> ImplementationSpec:
     return ImplementationSpec(
         source_path=str(path),
         service_name=title,
+        target_framework="streamlit",
         service_purpose=_section_text(sections, "서비스 목적"),
         target_users=_section_list(sections, "대상 사용자"),
         learning_goals=_extract_learning_goals(sections),

--- a/schemas/implementation/prototype_builder.py
+++ b/schemas/implementation/prototype_builder.py
@@ -27,7 +27,19 @@ class PrototypeBuilderInput(SchemaModel):
 class PrototypeBuilderOutput(SchemaModel):
     agent: AgentLabel | None = Field(default=None, description="Agent label metadata.")
     service_name: str = Field(description="Service name for the generated MVP.")
-    app_entrypoint: str = Field(description="Relative path to the generated Streamlit app.")
+    target_framework: str = Field(
+        default="streamlit",
+        description="Framework requested by the implementation spec.",
+    )
+    is_supported: bool = Field(
+        default=True,
+        description="Whether the requested target framework can be generated now.",
+    )
+    unsupported_reason: str = Field(
+        default="",
+        description="Reason why the requested target framework is not generated.",
+    )
+    app_entrypoint: str = Field(description="Relative path to the generated app.")
     generated_files: list[GeneratedFile] = Field(
         default_factory=list,
         description="Files that should be materialized for the MVP.",

--- a/schemas/planning_package/package.py
+++ b/schemas/planning_package/package.py
@@ -11,6 +11,10 @@ class ServiceMeta(SchemaModel):
     """Top-level service metadata for a planning output package."""
 
     service_name: str = Field(description="Canonical service name for downstream loaders.")
+    target_framework: str = Field(
+        default="streamlit",
+        description="Target application framework. Defaults to streamlit for compatibility.",
+    )
     target_user: str = Field(description="Primary target learner or user segment.")
     purpose: str = Field(description="Service purpose or intended learning outcome.")
     version: str = Field(description="Planning package version string.")

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -18,6 +18,7 @@ def test_parse_markdown_spec_extracts_expected_fields() -> None:
     spec = parse_markdown_spec(REPO_ROOT / "inputs" / "quiz_service_spec.md")
 
     assert spec.service_name == "질문력 향상 퀴즈 서비스 구현 명세서"
+    assert spec.target_framework == "streamlit"
     assert "중학생" in spec.target_users
     assert spec.learning_goals == ["구체성", "맥락성", "목적성"]
     assert spec.total_count == 8
@@ -156,3 +157,45 @@ def test_pipeline_records_input_intake_planning_review_warning(tmp_path: Path) -
     assert "## Input Intake Warning" in qa_report
     assert "llm_spec.generation_prompt" in final_summary
     assert "llm_spec.generation_prompt" in qa_report
+
+
+def test_pipeline_stops_before_local_checks_for_unsupported_framework(tmp_path: Path) -> None:
+    package_dir = REPO_ROOT / "inputs" / "mock_planning_outputs" / "question_quest_v0"
+    intake_result = load_input_intake(package_dir)
+    assert intake_result.implementation_spec is not None
+    unsupported_spec = intake_result.implementation_spec.model_copy(
+        update={"target_framework": "react"}
+    )
+
+    pipeline = ImplementationPipeline(
+        llm_client=FakeLLMClient(),
+        spec_path=package_dir,
+        implementation_spec=unsupported_spec,
+        input_intake_result=intake_result,
+        workspace_dir=tmp_path,
+        output_dir=tmp_path / "outputs",
+        app_target_path=tmp_path / "app.py",
+        enable_streamlit_smoke=False,
+    )
+
+    result = pipeline.run()
+
+    output_dir = tmp_path / "outputs"
+    prototype_output = json.loads(
+        (output_dir / "prototype_builder_output.json").read_text(encoding="utf-8")
+    )
+    execution_log = (output_dir / "execution_log.txt").read_text(encoding="utf-8")
+    qa_report = (output_dir / "qa_report.md").read_text(encoding="utf-8")
+    final_summary = (output_dir / "final_summary.md").read_text(encoding="utf-8")
+
+    assert result["prototype_builder_output"].is_supported is False
+    assert prototype_output["target_framework"] == "react"
+    assert prototype_output["is_supported"] is False
+    assert "not supported yet" in prototype_output["unsupported_reason"]
+    assert "[UNSUPPORTED] target_framework=react" in execution_log
+    assert "py_compile" not in execution_log
+    assert "local checks: NOT RUN" in qa_report
+    assert "target_framework: react" in final_summary
+    assert not (output_dir / "run_test_and_fix_output.json").exists()
+    assert not (output_dir / "qa_alignment_output.json").exists()
+    assert not (tmp_path / "app.py").exists()

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -199,3 +199,37 @@ def test_pipeline_stops_before_local_checks_for_unsupported_framework(tmp_path: 
     assert not (output_dir / "run_test_and_fix_output.json").exists()
     assert not (output_dir / "qa_alignment_output.json").exists()
     assert not (tmp_path / "app.py").exists()
+
+
+def test_pipeline_records_invalid_target_framework_reason(tmp_path: Path) -> None:
+    package_dir = REPO_ROOT / "inputs" / "mock_planning_outputs" / "question_quest_v0"
+    intake_result = load_input_intake(package_dir)
+    assert intake_result.implementation_spec is not None
+    invalid_spec = intake_result.implementation_spec.model_copy(
+        update={"target_framework": "stramlit"}
+    )
+
+    pipeline = ImplementationPipeline(
+        llm_client=FakeLLMClient(),
+        spec_path=package_dir,
+        implementation_spec=invalid_spec,
+        input_intake_result=intake_result,
+        workspace_dir=tmp_path,
+        output_dir=tmp_path / "outputs",
+        app_target_path=tmp_path / "app.py",
+        enable_streamlit_smoke=False,
+    )
+
+    pipeline.run()
+
+    output_dir = tmp_path / "outputs"
+    prototype_output = json.loads(
+        (output_dir / "prototype_builder_output.json").read_text(encoding="utf-8")
+    )
+    execution_log = (output_dir / "execution_log.txt").read_text(encoding="utf-8")
+
+    assert prototype_output["target_framework"] == "stramlit"
+    assert prototype_output["is_supported"] is False
+    assert "is not recognized" in prototype_output["unsupported_reason"]
+    assert "Known values: fastapi, nextjs, react, streamlit." in prototype_output["unsupported_reason"]
+    assert "[UNSUPPORTED] target_framework=stramlit" in execution_log

--- a/tests/test_planning_package_loader.py
+++ b/tests/test_planning_package_loader.py
@@ -8,7 +8,7 @@ from pathlib import Path
 
 import pytest
 
-from loaders import load_input_intake, load_planning_package
+from loaders import load_input_intake, load_planning_package, planning_package_to_implementation_spec
 from main import build_parser
 from orchestrator.app_source import build_content_filename
 from orchestrator.pipeline import ImplementationPipeline
@@ -24,6 +24,7 @@ def test_load_planning_package_reads_fixture_files() -> None:
     package = load_planning_package(PACKAGE_DIR)
 
     assert package.service_meta.service_name == "question_quest"
+    assert package.service_meta.target_framework == "streamlit"
     assert package.service_meta.version == "v0"
     assert package.evaluation_spec.rubric_criteria == ["구체성", "맥락성", "목적성"]
     assert package.evaluation_spec.grade_levels == ["브론즈", "실버", "골드", "플래티넘"]
@@ -79,6 +80,8 @@ def test_input_intake_generates_runtime_config_and_distribution() -> None:
 
     assert intake_result.status == ValidationStatus.AUTO_FIXED
     assert intake_result.runtime_config is not None
+    assert intake_result.implementation_spec is not None
+    assert intake_result.implementation_spec.target_framework == "streamlit"
     assert intake_result.runtime_config.service_slug == "question_quest"
     assert intake_result.runtime_config.target_framework == "streamlit"
     assert intake_result.runtime_config.content_output_filename == "question_quest_contents.json"
@@ -91,8 +94,22 @@ def test_input_intake_generates_runtime_config_and_distribution() -> None:
         "question_improvement": 2,
     }
     assert all(not path.startswith("/tmp/") for path in intake_result.source_paths)
-    assert intake_result.implementation_spec is not None
     assert intake_result.quality_judgement is not None
+
+
+def test_planning_package_adapter_forwards_target_framework() -> None:
+    package = load_planning_package(PACKAGE_DIR)
+    package = package.model_copy(
+        update={
+            "service_meta": package.service_meta.model_copy(
+                update={"target_framework": "react"}
+            )
+        }
+    )
+
+    spec = planning_package_to_implementation_spec(package, PACKAGE_DIR)
+
+    assert spec.target_framework == "react"
 
 
 def test_input_intake_marks_planning_review_without_blocking(tmp_path: Path) -> None:

--- a/tests/test_planning_package_schema.py
+++ b/tests/test_planning_package_schema.py
@@ -111,9 +111,26 @@ def build_quiz_payload() -> dict:
 )
 def test_planning_output_package_accepts_generic_education_services(payload: dict) -> None:
     package = PlanningOutputPackage.model_validate(payload)
+    expected = {
+        **payload,
+        "service_meta": {
+            "target_framework": "streamlit",
+            **payload["service_meta"],
+        },
+    }
 
     assert package.service_meta.service_name
-    assert package.model_dump() == payload
+    assert package.service_meta.target_framework == "streamlit"
+    assert package.model_dump() == expected
+
+
+def test_service_meta_accepts_explicit_target_framework() -> None:
+    payload = build_quiz_payload()
+    payload["service_meta"]["target_framework"] = "react"
+
+    package = PlanningOutputPackage.model_validate(payload)
+
+    assert package.service_meta.target_framework == "react"
 
 
 def test_planning_package_alias_points_to_same_model() -> None:

--- a/tests/test_prototype_builder_agent.py
+++ b/tests/test_prototype_builder_agent.py
@@ -48,6 +48,9 @@ def test_prototype_builder_generates_quest_template_from_planning_package() -> N
 
     source = output.generated_files[0].content
 
+    assert output.target_framework == "streamlit"
+    assert output.is_supported is True
+    assert output.unsupported_reason == ""
     assert "def api_session_start()" in source
     assert "def api_quest_submit(user_response: Any)" in source
     assert "def api_session_result()" in source
@@ -58,3 +61,31 @@ def test_prototype_builder_generates_quest_template_from_planning_package() -> N
     assert "question_quest_contents.json" in source
     assert "load_planning_package" not in source
     assert "constitution.md" not in source
+
+
+def test_prototype_builder_returns_unsupported_output_for_react() -> None:
+    fake = FakeLLMClient()
+    package = load_planning_package(PACKAGE_DIR)
+    spec = planning_package_to_implementation_spec(package, PACKAGE_DIR).model_copy(
+        update={"target_framework": "react"}
+    )
+
+    output = run_prototype_builder_agent(
+        PrototypeBuilderInput(
+            spec_intake_output=fake.generate_json(prompt="", response_model=SpecIntakeOutput),
+            requirement_mapping_output=fake.generate_json(
+                prompt="",
+                response_model=RequirementMappingOutput,
+            ),
+            content_interaction_output=_build_package_content_output(fake, spec.service_name),
+            implementation_spec=spec,
+        ),
+        fake,
+    )
+
+    assert output.target_framework == "react"
+    assert output.is_supported is False
+    assert "not supported yet" in output.unsupported_reason
+    assert "streamlit" in output.unsupported_reason
+    assert output.generated_files == []
+    assert output.app_entrypoint == ""

--- a/tests/test_prototype_builder_agent.py
+++ b/tests/test_prototype_builder_agent.py
@@ -89,3 +89,33 @@ def test_prototype_builder_returns_unsupported_output_for_react() -> None:
     assert "streamlit" in output.unsupported_reason
     assert output.generated_files == []
     assert output.app_entrypoint == ""
+
+
+def test_prototype_builder_distinguishes_invalid_target_framework() -> None:
+    fake = FakeLLMClient()
+    package = load_planning_package(PACKAGE_DIR)
+    spec = planning_package_to_implementation_spec(package, PACKAGE_DIR).model_copy(
+        update={"target_framework": "stramlit"}
+    )
+
+    output = run_prototype_builder_agent(
+        PrototypeBuilderInput(
+            spec_intake_output=fake.generate_json(prompt="", response_model=SpecIntakeOutput),
+            requirement_mapping_output=fake.generate_json(
+                prompt="",
+                response_model=RequirementMappingOutput,
+            ),
+            content_interaction_output=_build_package_content_output(fake, spec.service_name),
+            implementation_spec=spec,
+        ),
+        fake,
+    )
+
+    assert output.target_framework == "stramlit"
+    assert output.is_supported is False
+    assert output.generated_files == []
+    assert (
+        output.unsupported_reason
+        == "target_framework 'stramlit' is not recognized. "
+        "Known values: fastapi, nextjs, react, streamlit."
+    )

--- a/validators/planning_package_validator.py
+++ b/validators/planning_package_validator.py
@@ -96,12 +96,13 @@ def validate_and_normalize_planning_package(
             )
         )
 
+    target_framework = implementation_spec.target_framework or "streamlit"
     auto_fixes.append(
         AutoFixRecord(
             field_path="runtime_config.target_framework",
             before=None,
-            after="streamlit",
-            reason="target_framework 누락 시 기본 실행 프레임워크를 streamlit으로 설정했다.",
+            after=target_framework,
+            reason="ImplementationSpec 기준 target_framework 실행 값을 기록했다.",
         )
     )
 
@@ -141,7 +142,7 @@ def validate_and_normalize_planning_package(
 
     runtime_config = InputRuntimeConfig(
         service_slug=service_slug,
-        target_framework="streamlit",
+        target_framework=target_framework,
         content_output_filename=content_output_filename,
         normalized_source_path=normalized_source_path,
         content_distribution=content_distribution,


### PR DESCRIPTION
## 요약
- `ImplementationSpec.target_framework`와 `PlanningOutputPackage.service_meta.target_framework`를 추가했습니다.
- 기본값은 `streamlit`이며, 기존 planning package 입력은 필드가 없어도 그대로 동작합니다.
- Prototype Builder는 `ImplementationSpec.target_framework`를 기준으로 분기합니다.
- 현재는 `streamlit`만 지원하고, `react`, `fastapi`, `nextjs` 등은 unsupported output/log를 남긴 뒤 local checks 전에 중단합니다.

## 주요 변경
- `target_framework` 기본값을 스키마와 loader adapter에 반영했습니다.
- #29 `InputRuntimeConfig.target_framework`가 최종 runtime 기준인 `ImplementationSpec.target_framework`와 일치하도록 정리했습니다.
- `PrototypeBuilderOutput`에 `target_framework`, `is_supported`, `unsupported_reason`을 추가했습니다.
- unsupported framework 경로에서 `prototype_builder_output.json`, `execution_log.txt`, `qa_report.md`, `final_summary.md`에 중단 이유를 남깁니다.
- Streamlit-specific 처리는 Prototype Builder/app source/local check 계층에만 유지했습니다.

## 검증
- `python -m pytest -q` → `38 passed`
- `python main.py --input-package inputs/mock_planning_outputs/question_quest_v0/` → 성공
- live local checks: `py_compile PASS`, `package_pytest PASS`, `streamlit_smoke PASS`
- live outputs 확인: `input_intake_report.json`, `prototype_builder_output.json` 모두 `target_framework=streamlit`

## 다음 단계
- #28에서 `target_framework == "streamlit"` 경로 안에 LLM 기반 app.py 생성과 리플렉션 재생성 구조를 연결하면 됩니다.