### PR TITLE
Quest MVP 런타임 버그를 수정한다

### DIFF
--- a/agents/implementation/prototype_builder_agent.py
+++ b/agents/implementation/prototype_builder_agent.py
@@ -353,6 +353,9 @@ def _validate_generated_app_source(
         raise InvalidAppSourceError(
             "app_source must show user-facing guidance when the content file is missing."
         )
+    if "st.experimental_rerun" in app_source:
+        raise InvalidAppSourceError("app_source must use st.rerun() instead of st.experimental_rerun().")
+    _validate_state_machine_contract(app_source)
     try:
         compile(app_source, "app.py", "exec")
     except SyntaxError as exc:
@@ -377,6 +380,44 @@ def _validate_generated_app_source(
                 f"app_source must not read planning package input at runtime: {forbidden}."
             )
     return app_source.rstrip() + "\n"
+
+
+def _validate_state_machine_contract(app_source: str) -> None:
+    required_markers = [
+        "current_screen",
+        "SCREEN_MULTIPLE_CHOICE_RESULT",
+        "SCREEN_IMPROVEMENT_RESULT",
+        "st.rerun()",
+    ]
+    for marker in required_markers:
+        if marker not in app_source:
+            raise InvalidAppSourceError(
+                f"app_source must include state-machine marker: {marker}."
+            )
+
+    raw_field_patterns = [
+        'quest["item_id"]',
+        "quest['item_id']",
+        'quest.get("item_id"',
+        "quest.get('item_id'",
+        'quest["choices"]',
+        "quest['choices']",
+        'quest.get("choices"',
+        "quest.get('choices'",
+    ]
+    function_pairs = [
+        ("api_quest_submit", "api_session_result"),
+        ("render_multiple_choice_screen", "render_multiple_choice_result"),
+        ("render_multiple_choice_result", "render_improvement_screen"),
+        ("render_improvement_screen", "render_improvement_result"),
+    ]
+    for start_name, end_name in function_pairs:
+        block = _extract_function_block(app_source, start_name, end_name)
+        for pattern in raw_field_patterns:
+            if pattern in block:
+                raise InvalidAppSourceError(
+                    f"{start_name} must use normalized quest fields only; found raw field reference {pattern}."
+                )
 
 
 def _validate_function_call_arity(*, app_source: str, function_name: str) -> None:
@@ -490,6 +531,16 @@ def _has_missing_content_guidance(app_source: str) -> bool:
 
 def _normalize_source_for_contract_checks(app_source: str) -> str:
     return "".join(app_source.lower().split())
+
+
+def _extract_function_block(app_source: str, start_name: str, end_name: str) -> str:
+    start_marker = f"def {start_name}"
+    end_marker = f"def {end_name}"
+    if start_marker not in app_source or end_marker not in app_source:
+        raise InvalidAppSourceError(
+            f"app_source must include function block {start_name} before {end_name}."
+        )
+    return app_source.split(start_marker, 1)[1].split(end_marker, 1)[0]
 
 
 def _strip_python_fence(source: str) -> str:

--- a/app.py
+++ b/app.py
@@ -1,349 +1,697 @@
-import streamlit as st
-import json
-import os
-from pathlib import Path
-from typing import Dict, Any, List, Tuple, Optional
+from __future__ import annotations
 
-# Configuration
-APP_DIR = Path(__file__).parent
+import json
+import re
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+import streamlit as st
+
+
+APP_DIR = Path(__file__).resolve().parent
+SERVICE_NAME = "질문력 강화 퀘스트"
 CONTENT_FILENAME = "question_quest_contents.json"
 OUTPUT_PATH = APP_DIR / "outputs" / CONTENT_FILENAME
 FALLBACK_OUTPUT_PATH = APP_DIR / CONTENT_FILENAME
 CONTENT_CANDIDATE_PATHS = [OUTPUT_PATH, FALLBACK_OUTPUT_PATH]
 
-# Session state initialization
-if "session_state" not in st.session_state:
-    st.session_state.session_state = {
-        "session_id": None,
-        "quests": [],
-        "current_quest_index": 0,
-        "user_progress": {
-            "cumulative_score": 0,
-            "current_grade": "bronze",
-            "completed_session_count": 0
-        },
-        "session_score": 0,
-        "answers": []
-    }
+SCREENS = ["S0", "S1", "S2", "S3", "S4", "S5"]
+SCREEN_START = "S0"
+SCREEN_MULTIPLE_CHOICE = "S1"
+SCREEN_MULTIPLE_CHOICE_RESULT = "S2"
+SCREEN_IMPROVEMENT = "S3"
+SCREEN_IMPROVEMENT_RESULT = "S4"
+SCREEN_SESSION_RESULT = "S5"
 
-# Content loading
-@st.cache_data(show_spinner=False)
-def load_content() -> Dict[str, Any]:
-    for path in CONTENT_CANDIDATE_PATHS:
-        if path.exists():
-            with open(path, 'r', encoding='utf-8') as f:
-                return json.load(f)
-    st.error(f"콘텐츠 파일을 찾을 수 없습니다. 다음 경로에 파일이 있는지 확인하세요: {', '.join(str(p) for p in CONTENT_CANDIDATE_PATHS)}")
-    return {}
+API_ENDPOINTS = [
+    "/api/session/start",
+    "/api/quest/submit",
+    "/api/session/result",
+]
 
-# Content loading
-content = load_content()
-items = content.get("items", [])
-answer_key = content.get("answer_key", {})
-explanations = content.get("explanations", {})
-learning_points = content.get("learning_points", {})
+SCORE_RULES = {
+    "answer_score_rules": {
+        "multiple_choice_correct": 20,
+        "multiple_choice_incorrect": 5,
+        "improvement_excellent": 30,
+        "improvement_good": 20,
+        "improvement_needs_work": 10,
+    },
+    "service_grades": {
+        "브론즈": [0, 99],
+        "실버": [100, 299],
+        "골드": [300, 599],
+        "플래티넘": [600, None],
+    },
+}
+GRADE_LEVELS = ["브론즈", "실버", "골드", "플래티넘"]
+GRADE_THRESHOLDS = {
+    "브론즈": {"min_score": 0, "max_score": 99},
+    "실버": {"min_score": 100, "max_score": 299},
+    "골드": {"min_score": 300, "max_score": 599},
+    "플래티넘": {"min_score": 600, "max_score": None},
+}
 
-# Helper functions
+IMPROVEMENT_MIN_LENGTH = 10
+IMPROVEMENT_MAX_LENGTH = 300
+SPECIFICITY_MARKERS = [
+    "예시",
+    "단계",
+    "문장",
+    "문단",
+    "그래프",
+    "수식",
+    "비유",
+    "원인",
+    "방법",
+    "비교",
+    "3개",
+    "한 문장",
+    "단계별",
+    "구체",
+    "어떤 문제",
+    "왜",
+    "어떻게",
+]
+CONTEXT_MARKERS = [
+    "국어",
+    "수학",
+    "과학",
+    "사회",
+    "역사",
+    "영어",
+    "숙제",
+    "발표",
+    "시험",
+    "수행평가",
+    "수업",
+    "실험",
+    "독후감",
+    "글쓰기",
+    "프로젝트",
+    "과제",
+]
+PURPOSE_MARKERS = [
+    "설명",
+    "예시",
+    "풀이",
+    "방법",
+    "이유",
+    "비교",
+    "알려줘",
+    "보여줘",
+    "정리",
+    "도와줘",
+    "알고 싶",
+    "말해줘",
+    "어떻게",
+    "왜",
+]
 
-def resolve_content_path() -> Optional[Path]:
+
+def resolve_content_path() -> Path | None:
     for path in CONTENT_CANDIDATE_PATHS:
         if path.exists():
             return path
     return None
 
+
+@st.cache_data(show_spinner=False)
+def load_quest_contents() -> dict[str, Any]:
+    content_path = resolve_content_path()
+    if content_path is None:
+        return {}
+    return json.loads(content_path.read_text(encoding="utf-8"))
+
+
+def ensure_state() -> None:
+    defaults = {
+        "current_screen": SCREEN_START,
+        "session_id": "",
+        "session_quests": [],
+        "current_quest_index": 0,
+        "session_score": 0,
+        "cumulative_score": 0,
+        "current_grade": GRADE_LEVELS[0],
+        "completed_session_count": 0,
+        "last_result": None,
+        "last_submission": "",
+        "session_finalized": False,
+        "grade_up_event": None,
+        "previous_grade": GRADE_LEVELS[0],
+        "last_api_response": None,
+    }
+    for key, value in defaults.items():
+        st.session_state.setdefault(key, value)
+
+
+def reset_session_progress() -> None:
+    st.session_state.session_id = ""
+    st.session_state.session_quests = []
+    st.session_state.current_quest_index = 0
+    st.session_state.session_score = 0
+    st.session_state.last_result = None
+    st.session_state.last_submission = ""
+    st.session_state.session_finalized = False
+    st.session_state.grade_up_event = None
+    st.session_state.last_api_response = None
+    st.session_state.current_screen = SCREEN_START
+
+
+def truncate_feedback(text: str, limit: int = 150) -> str:
+    compact = " ".join(text.split())
+    return compact[:limit].rstrip()
+
+
+def contains_any(text: str, markers: list[str]) -> bool:
+    lowered = text.lower()
+    return any(marker.lower() in lowered for marker in markers)
+
+
+def get_grade_rank(grade: str) -> int:
+    try:
+        return GRADE_LEVELS.index(grade)
+    except ValueError:
+        return -1
+
+
 def determine_grade(score: int) -> str:
-    if score >= 600:
-        return "platinum"
-    elif score >= 300:
-        return "gold"
-    elif score >= 100:
-        return "silver"
-    else:
-        return "bronze"
+    for grade in GRADE_LEVELS:
+        rule = GRADE_THRESHOLDS.get(grade, {})
+        min_score = int(rule.get("min_score", 0))
+        max_score = rule.get("max_score")
+        if score >= min_score and (max_score is None or score <= int(max_score)):
+            return grade
+    return GRADE_LEVELS[0]
+
+
+def normalize_quest_item(item: dict[str, Any]) -> dict[str, Any]:
+    quiz_type = str(item.get("quiz_type") or "")
+    inferred_difficulty = "intro" if quiz_type == "multiple_choice" else "main"
+    options = list(item.get("choices", []))
+    correct_option_text = item.get("correct_choice")
+    correct_option_index = (
+        options.index(correct_option_text) if correct_option_text in options else None
+    )
+    question = item.get("question") or "질문을 더 좋게 만들어 보세요."
+    return {
+        "quest_id": str(item.get("item_id") or uuid4()),
+        "quest_type": quiz_type,
+        "difficulty": item.get("difficulty") or inferred_difficulty,
+        "topic_context": item.get("topic_context") or item.get("learning_dimension") or SERVICE_NAME,
+        "title": item.get("title") or question,
+        "question": question,
+        "original_question": item.get("original_question") or question,
+        "options": options,
+        "correct_option_text": correct_option_text,
+        "correct_option_index": correct_option_index,
+        "explanation": item.get("explanation") or "",
+        "learning_point": item.get("learning_point") or "",
+    }
+
+
+def build_session_quests(data: dict[str, Any]) -> list[dict[str, Any]]:
+    normalized = [normalize_quest_item(item) for item in data.get("items", [])]
+
+    intro_candidates = [
+        quest
+        for quest in normalized
+        if quest.get("difficulty") == "intro" and quest.get("quest_type") == "multiple_choice"
+    ]
+    main_candidates = [
+        quest
+        for quest in normalized
+        if quest.get("difficulty") == "main"
+        and quest.get("quest_type") == "question_improvement"
+    ]
+    if intro_candidates and len(main_candidates) >= 2:
+        return [intro_candidates[0], main_candidates[0], main_candidates[1]]
+
+    multiple_choice = [
+        quest for quest in normalized if quest.get("quest_type") == "multiple_choice"
+    ]
+    question_improvement = [
+        quest
+        for quest in normalized
+        if quest.get("quest_type") == "question_improvement"
+    ]
+    if len(multiple_choice) >= 1 and len(question_improvement) >= 2:
+        return [
+            multiple_choice[0],
+            question_improvement[0],
+            question_improvement[1],
+        ]
+
+    raise ValueError("퀘스트를 불러오지 못했어요. multiple_choice 1개와 question_improvement 2개가 필요합니다.")
+
+
+def screen_for_quest(quest: dict[str, Any], *, feedback: bool = False) -> str:
+    quest_type = quest.get("quest_type")
+    if quest_type == "multiple_choice":
+        return SCREEN_MULTIPLE_CHOICE_RESULT if feedback else SCREEN_MULTIPLE_CHOICE
+    return SCREEN_IMPROVEMENT_RESULT if feedback else SCREEN_IMPROVEMENT
+
+
+def calculate_multiple_choice_score(is_correct: bool) -> int:
+    rules = SCORE_RULES.get("answer_score_rules", {})
+    return int(
+        rules.get(
+            "multiple_choice_correct" if is_correct else "multiple_choice_incorrect",
+            20 if is_correct else 5,
+        )
+    )
+
+
+def calculate_improvement_score(overall: str) -> int:
+    rules = SCORE_RULES.get("answer_score_rules", {})
+    defaults = {
+        "excellent": 30,
+        "good": 20,
+        "needs_work": 10,
+    }
+    return int(rules.get(f"improvement_{overall}", defaults.get(overall, 10)))
+
+
+def evaluate_specificity(text: str) -> str:
+    cleaned = text.strip()
+    marker_hit = contains_any(cleaned, SPECIFICITY_MARKERS) or bool(re.search(r"\d", cleaned))
+    if len(cleaned) >= 28 and marker_hit:
+        return "excellent"
+    if len(cleaned) >= 18 or marker_hit:
+        return "good"
+    return "needs_work"
+
+
+def evaluate_context(text: str) -> str:
+    cleaned = text.strip()
+    marker_count = sum(1 for marker in CONTEXT_MARKERS if marker in cleaned)
+    if marker_count >= 2:
+        return "excellent"
+    if marker_count >= 1:
+        return "good"
+    return "needs_work"
+
+
+def evaluate_purpose(text: str) -> str:
+    cleaned = text.strip()
+    marker_count = sum(1 for marker in PURPOSE_MARKERS if marker in cleaned)
+    if marker_count >= 2 and len(cleaned) >= 22:
+        return "excellent"
+    if marker_count >= 1:
+        return "good"
+    return "needs_work"
+
 
 def evaluate_improvement_question(
     user_response: str,
     original_question: str,
-    topic_context: str
-) -> Tuple[Dict[str, str], str, int]:
-    # Rule-based evaluation instead of LLM
-    specificity_score = 0
-    context_score = 0
-    purpose_score = 0
+    topic_context: str,
+) -> tuple[dict[str, str], str, int]:
+    _ = original_question
+    _ = topic_context
 
-    # Specificity check
-    if any(keyword in user_response.lower() for keyword in ["무엇", "어떤", "어떤 것", "어떤 개념"]):
-        specificity_score += 1
-    if any(keyword in user_response.lower() for keyword in ["구체적으로", "명확하게", "자세히"]):
-        specificity_score += 1
-
-    # Context check
-    if any(keyword in user_response.lower() for keyword in ["숙제", "시험", "과제", "수업", "공부"]):
-        context_score += 1
-    if topic_context.lower() in user_response.lower():
-        context_score += 1
-
-    # Purpose check
-    if any(keyword in user_response.lower() for keyword in ["알려줘", "설명해줘", "예시", "풀이", "방법"]):
-        purpose_score += 1
-    if any(keyword in user_response.lower() for keyword in ["예시", "예시 들어줘", "예를 들어"]):
-        purpose_score += 1
-
-    # Convert scores to ratings
-    def get_rating(score):
-        if score >= 2:
-            return "excellent"
-        elif score == 1:
-            return "good"
-        else:
-            return "needs_work"
-
-    rubric_result = {
-        "specificity": get_rating(specificity_score),
-        "context": get_rating(context_score),
-        "purpose": get_rating(purpose_score),
-        "overall": get_rating(specificity_score + context_score + purpose_score)
-    }
-
-    # Generate feedback
-    if rubric_result["overall"] == "excellent":
-        feedback = "질문이 아주 명확해졌어요! 무엇을, 왜, 어떻게가 모두 잘 드러나 있어요."
-        score = 30
-    elif rubric_result["overall"] == "good":
-        feedback = "좋아졌어요! 질문이 더 명확해졌어요."
-        score = 20
+    specificity = evaluate_specificity(user_response)
+    context = evaluate_context(user_response)
+    purpose = evaluate_purpose(user_response)
+    grades = [specificity, context, purpose]
+    if all(grade == "excellent" for grade in grades):
+        overall = "excellent"
+    elif any(grade == "needs_work" for grade in grades):
+        overall = "needs_work"
     else:
-        feedback = "한 부분이 더 명확해지면 좋겠어요."
-        score = 10
+        overall = "good"
 
-    return rubric_result, feedback, score
-
-# API functions
-def api_session_start(user_id: str = "anonymous") -> Dict[str, Any]:
-    session_id = f"session_{st.session_state.session_state['user_progress']['completed_session_count'] + 1}"
-
-    # Select quests (1 intro + 2 main)
-    intro_quest = next(item for item in items if item["difficulty"] == "intro")
-    main_quests = [item for item in items if item["difficulty"] == "main"][:2]
-    quests = [intro_quest] + main_quests
-
-    st.session_state.session_state.update({
-        "session_id": session_id,
-        "quests": quests,
-        "current_quest_index": 0,
-        "session_score": 0,
-        "answers": []
-    })
-
-    return {
-        "session_id": session_id,
-        "quests": [
-            {
-                "quest_id": quest["item_id"],
-                "quest_type": quest["quiz_type"],
-                "difficulty": quest["difficulty"],
-                "topic_context": quest["topic_context"],
-                "original_question": quest["original_question"],
-                "options": quest.get("choices", [])
-            }
-            for quest in quests
-        ],
-        "user_progress": st.session_state.session_state["user_progress"]
+    rubric = {
+        "specificity": specificity,
+        "context": context,
+        "purpose": purpose,
+        "overall": overall,
     }
+    feedback = build_improvement_feedback(rubric)
+    score = calculate_improvement_score(overall)
+    return rubric, feedback, score
 
-def api_quest_submit(quest: Dict[str, Any], user_response: Any) -> Dict[str, Any]:
-    session_state = st.session_state.session_state
-    quest_id = quest["quest_id"]
-    quest_type = quest["quest_type"]
 
-    if quest_type == "multiple_choice":
-        # Validate response
-        if not isinstance(user_response, int) or not 0 <= user_response < len(quest["options"]):
-            st.error("선택지를 골라주세요")
+def build_improvement_feedback(rubric: dict[str, str]) -> str:
+    messages: list[str] = []
+    if rubric.get("specificity") == "excellent":
+        messages.append("무엇을 묻는지가 구체적으로 드러나요.")
+    elif rubric.get("specificity") == "good":
+        messages.append("질문의 대상은 보이지만 조건을 조금 더 넣으면 좋아요.")
+    else:
+        messages.append("무엇을 궁금해하는지 더 구체적으로 적어보세요.")
+
+    if rubric.get("context") == "excellent":
+        messages.append("과목이나 과제 상황이 분명해져요.")
+    elif rubric.get("context") == "good":
+        messages.append("맥락 단서가 일부 보이지만 상황을 더 드러낼 수 있어요.")
+    else:
+        messages.append("국어 숙제, 발표 준비처럼 학습 상황을 넣어보세요.")
+
+    if rubric.get("purpose") == "excellent":
+        messages.append("원하는 도움의 형태가 분명해요.")
+    elif rubric.get("purpose") == "good":
+        messages.append("도움 요청은 있지만 어떤 답을 원하는지 더 말해보세요.")
+    else:
+        messages.append("예시, 풀이, 이유처럼 원하는 도움 형태를 함께 써보세요.")
+
+    header_map = {
+        "excellent": "질문이 아주 명확해졌어요!",
+        "good": "좋아졌어요!",
+        "needs_work": "한 부분만 더 보완해볼까요?",
+    }
+    header = header_map.get(rubric.get("overall"), "좋아졌어요!")
+    return truncate_feedback(f"{header} {' '.join(messages)}")
+
+
+def build_multiple_choice_feedback(quest: dict[str, Any], is_correct: bool) -> str:
+    base = quest.get("explanation") or "정답 선택지가 더 좋은 질문입니다."
+    prefix = "정답입니다!" if is_correct else "이 질문도 좋아요."
+    return truncate_feedback(f"{prefix} {base}")
+
+
+def api_session_start() -> dict[str, Any]:
+    data = load_quest_contents()
+    session_quests = build_session_quests(data)
+    response = {
+        "session_id": str(uuid4()),
+        "quests": session_quests,
+        "user_progress": {
+            "cumulative_score": st.session_state.cumulative_score,
+            "current_grade": st.session_state.current_grade,
+            "completed_session_count": st.session_state.completed_session_count,
+        },
+    }
+    st.session_state.session_id = response["session_id"]
+    st.session_state.session_quests = session_quests
+    st.session_state.current_quest_index = 0
+    st.session_state.session_score = 0
+    st.session_state.last_result = None
+    st.session_state.last_submission = ""
+    st.session_state.session_finalized = False
+    st.session_state.grade_up_event = None
+    st.session_state.last_api_response = response
+    st.session_state.current_screen = screen_for_quest(session_quests[0])
+    return response
+
+
+def api_quest_submit(user_response: Any) -> dict[str, Any]:
+    quest = st.session_state.session_quests[st.session_state.current_quest_index]
+    is_session_complete = (
+        st.session_state.current_quest_index == len(st.session_state.session_quests) - 1
+    )
+
+    if quest.get("quest_type") == "multiple_choice":
+        if not isinstance(user_response, str) or user_response not in quest.get("options", []):
             return {"error_code": "E_NO_SELECTION", "error_message": "선택지를 골라주세요"}
 
-        # Get correct answer
-        correct_index = quest["choices"].index(answer_key[quest_id])
-        is_correct = (user_response == correct_index)
-
-        # Calculate score
-        if is_correct:
-            earned_score = 20
-            feedback = f"정답입니다! {explanations[quest_id]}"
-        else:
-            earned_score = 5
-            feedback = f"이 질문도 좋아요. {explanations[quest_id]}"
-
-        evaluation = {
-            "evaluation_type": "correctness",
-            "is_correct": is_correct,
-            "feedback": feedback
+        is_correct = user_response == quest.get("correct_option_text")
+        earned_score = calculate_multiple_choice_score(is_correct)
+        response = {
+            "answer_id": str(uuid4()),
+            "evaluation": {
+                "evaluation_type": "correctness",
+                "is_correct": is_correct,
+                "feedback": build_multiple_choice_feedback(quest, is_correct),
+            },
+            "earned_score": earned_score,
+            "correct_option_index": quest.get("correct_option_index"),
+            "is_session_complete": is_session_complete,
         }
-    else:  # question_improvement
-        # Validate response
-        if not isinstance(user_response, str):
-            st.error("질문을 작성해주세요")
+    else:
+        if not isinstance(user_response, str) or not user_response.strip():
             return {"error_code": "E_EMPTY_INPUT", "error_message": "질문을 작성해주세요"}
-        if len(user_response.strip()) < 10:
-            st.error("조금 더 자세히 작성해주세요 (최소 10자)")
-            return {"error_code": "E_TOO_SHORT", "error_message": "조금 더 자세히 작성해주세요 (최소 10자)"}
+        if len(user_response.strip()) < IMPROVEMENT_MIN_LENGTH:
+            return {
+                "error_code": "E_TOO_SHORT",
+                "error_message": "조금 더 자세히 작성해주세요 (최소 10자)",
+            }
 
-        # Evaluate response
-        rubric_result, feedback, earned_score = evaluate_improvement_question(
-            user_response,
-            quest["original_question"],
-            quest["topic_context"]
+        rubric, feedback, earned_score = evaluate_improvement_question(
+            user_response.strip(),
+            quest.get("original_question", ""),
+            quest.get("topic_context", ""),
+        )
+        response = {
+            "answer_id": str(uuid4()),
+            "evaluation": {
+                "evaluation_type": "rubric",
+                "rubric_result": rubric,
+                "feedback": feedback,
+            },
+            "earned_score": earned_score,
+            "is_session_complete": is_session_complete,
+        }
+
+    st.session_state.session_score += int(response["earned_score"])
+    st.session_state.last_result = response
+    st.session_state.last_submission = user_response
+    st.session_state.last_api_response = response
+    st.session_state.current_screen = screen_for_quest(quest, feedback=True)
+    return response
+
+
+def api_session_result() -> dict[str, Any]:
+    if not st.session_state.session_finalized:
+        previous_grade = st.session_state.current_grade
+        cumulative_score = st.session_state.cumulative_score + st.session_state.session_score
+        new_grade = determine_grade(cumulative_score)
+        grade_up_event = get_grade_rank(new_grade) > get_grade_rank(previous_grade)
+        st.session_state.previous_grade = previous_grade
+        st.session_state.cumulative_score = cumulative_score
+        st.session_state.current_grade = new_grade
+        st.session_state.completed_session_count += 1
+        st.session_state.session_finalized = True
+        st.session_state.grade_up_event = {
+            "grade_up_event": grade_up_event,
+            "previous_grade": previous_grade,
+            "new_grade": new_grade,
+        }
+
+    grade_event = st.session_state.grade_up_event or {
+        "grade_up_event": False,
+        "previous_grade": st.session_state.current_grade,
+        "new_grade": st.session_state.current_grade,
+    }
+    response = {
+        "session_id": st.session_state.session_id,
+        "session_score": st.session_state.session_score,
+        "user_progress": {
+            "cumulative_score": st.session_state.cumulative_score,
+            "current_grade": st.session_state.current_grade,
+            "completed_session_count": st.session_state.completed_session_count,
+        },
+        "grade_up_event": grade_event["grade_up_event"],
+        "previous_grade": grade_event["previous_grade"],
+        "new_grade": grade_event["new_grade"],
+    }
+    st.session_state.last_api_response = response
+    return response
+
+
+def render_sidebar() -> None:
+    content_path = resolve_content_path()
+    with st.sidebar:
+        st.subheader("세션 상태")
+        st.write(f"현재 화면: {st.session_state.current_screen}")
+        st.write(f"현재 등급: {st.session_state.current_grade or '없음'}")
+        st.write(f"누적 점수: {st.session_state.cumulative_score}")
+        st.write(f"세션 점수: {st.session_state.session_score}")
+        st.subheader("화면 구성")
+        for screen in SCREENS:
+            st.write(f"- {screen}")
+        st.subheader("내부 API")
+        for endpoint in API_ENDPOINTS:
+            st.write(f"- {endpoint}")
+        if content_path is None:
+            st.caption(
+                "콘텐츠 파일을 찾지 못했습니다: "
+                + ", ".join(str(path) for path in CONTENT_CANDIDATE_PATHS)
+            )
+        else:
+            st.caption(f"콘텐츠 파일: {content_path}")
+
+
+def render_start_screen() -> None:
+    st.title("오늘의 질문력 퀘스트")
+    st.caption(SERVICE_NAME)
+    st.write("3개의 퀘스트를 풀고 질문력 점수를 쌓아보세요!")
+    col1, col2 = st.columns(2)
+    col1.metric("현재 등급", st.session_state.current_grade or "-")
+    col2.metric("누적 점수", st.session_state.cumulative_score)
+    if st.button("세션 시작", type="primary"):
+        try:
+            api_session_start()
+        except ValueError as error:
+            st.error(str(error))
+        else:
+            st.rerun()
+
+
+def render_multiple_choice_screen() -> None:
+    quest = st.session_state.session_quests[st.session_state.current_quest_index]
+    st.subheader("객관식 퀘스트")
+    st.caption(
+        f"퀘스트 {st.session_state.current_quest_index + 1} / "
+        f"{len(st.session_state.session_quests)}"
+    )
+    st.write(f"학습 맥락: {quest.get('topic_context') or SERVICE_NAME}")
+    st.write(f"원본 질문: {quest.get('original_question') or quest.get('question')}")
+    st.info(quest.get("question") or "이 질문을 더 좋게 바꾼 선택지를 골라보세요.")
+    choice_key = f"choice_{quest['quest_id']}"
+    st.radio("선택지를 고르세요.", quest.get("options", []), index=None, key=choice_key)
+    if st.button("제출", type="primary"):
+        selected = st.session_state.get(choice_key)
+        response = api_quest_submit(selected)
+        if "error_code" in response:
+            st.warning(response["error_message"])
+        else:
+            st.rerun()
+
+
+def render_multiple_choice_result() -> None:
+    quest = st.session_state.session_quests[st.session_state.current_quest_index]
+    result = st.session_state.last_result or {}
+    evaluation = result.get("evaluation", {})
+    is_correct = bool(evaluation.get("is_correct"))
+    st.subheader("객관식 결과")
+    st.success("정답입니다!" if is_correct else "이 질문도 좋아요")
+    st.write(f"내가 고른 답: {st.session_state.last_submission or '미응답'}")
+    st.write(f"정답: {quest.get('correct_option_text', '-')}")
+    st.write(f"해설: {evaluation.get('feedback', quest.get('explanation', ''))}")
+    if quest.get("learning_point"):
+        st.write(f"학습 포인트: {quest['learning_point']}")
+    st.write(f"획득 점수: +{result.get('earned_score', 0)}점")
+    if st.button("다음 퀘스트로", type="primary"):
+        st.session_state.current_quest_index += 1
+        st.session_state.last_result = None
+        st.session_state.last_submission = ""
+        next_quest = st.session_state.session_quests[st.session_state.current_quest_index]
+        st.session_state.current_screen = screen_for_quest(next_quest)
+        st.rerun()
+
+
+def render_improvement_screen() -> None:
+    quest = st.session_state.session_quests[st.session_state.current_quest_index]
+    st.subheader("질문 더 좋게 만들기")
+    st.caption(
+        f"퀘스트 {st.session_state.current_quest_index + 1} / "
+        f"{len(st.session_state.session_quests)}"
+    )
+    st.write(f"학습 맥락: {quest.get('topic_context') or SERVICE_NAME}")
+    st.write(f"원본 질문: {quest.get('original_question') or quest.get('question')}")
+    st.info("이 질문을 더 명확하게 바꿔보세요. 무엇을, 왜, 어떻게가 들어가면 좋아요.")
+    text_key = f"text_{quest['quest_id']}"
+    user_text = st.text_area(
+        "질문 다시 쓰기",
+        key=text_key,
+        max_chars=IMPROVEMENT_MAX_LENGTH,
+        height=180,
+    )
+    st.caption(f"{len(user_text)} / {IMPROVEMENT_MAX_LENGTH}")
+    if st.button("제출", type="primary"):
+        response = api_quest_submit(user_text.strip())
+        if "error_code" in response:
+            st.warning(response["error_message"])
+        else:
+            st.rerun()
+
+
+def render_improvement_result() -> None:
+    quest = st.session_state.session_quests[st.session_state.current_quest_index]
+    result = st.session_state.last_result or {}
+    evaluation = result.get("evaluation", {})
+    rubric = evaluation.get("rubric_result", {})
+    overall = rubric.get("overall", "good")
+    header_map = {
+        "excellent": "아주 명확해졌어요!",
+        "good": "좋아졌어요!",
+        "needs_work": "한 부분만 더 보완해볼까요?",
+    }
+    st.subheader("개선형 퀘스트 결과")
+    st.success(header_map.get(overall, "좋아졌어요!"))
+    col1, col2 = st.columns(2)
+    col1.markdown("**Before**")
+    col1.write(quest.get("original_question") or quest.get("question"))
+    col2.markdown("**After**")
+    col2.write(st.session_state.last_submission or "미응답")
+    st.write(
+        " / ".join(
+            [
+                f"구체성: {rubric.get('specificity', '-')}",
+                f"맥락성: {rubric.get('context', '-')}",
+                f"목적성: {rubric.get('purpose', '-')}",
+            ]
+        )
+    )
+    st.write(f"피드백: {evaluation.get('feedback', '')}")
+    if quest.get("learning_point"):
+        st.write(f"학습 포인트: {quest['learning_point']}")
+    st.write(f"획득 점수: +{result.get('earned_score', 0)}점")
+    button_label = (
+        "결과 보기"
+        if st.session_state.current_quest_index >= len(st.session_state.session_quests) - 1
+        else "다음 퀘스트로"
+    )
+    if st.button(button_label, type="primary"):
+        st.session_state.last_result = None
+        st.session_state.last_submission = ""
+        if st.session_state.current_quest_index >= len(st.session_state.session_quests) - 1:
+            st.session_state.current_screen = SCREEN_SESSION_RESULT
+        else:
+            st.session_state.current_quest_index += 1
+            next_quest = st.session_state.session_quests[st.session_state.current_quest_index]
+            st.session_state.current_screen = screen_for_quest(next_quest)
+        st.rerun()
+
+
+def render_session_result() -> None:
+    result = api_session_result()
+    st.subheader("오늘의 퀘스트 완료!")
+    col1, col2, col3 = st.columns(3)
+    col1.metric("이번 세션 점수", f"+{result['session_score']}점")
+    col2.metric("누적 총점", result["user_progress"]["cumulative_score"])
+    col3.metric("현재 등급", result["user_progress"]["current_grade"])
+    if result.get("grade_up_event"):
+        st.success(f"축하해요! 이제 {result.get('new_grade')} 단계예요")
+    st.write(f"완료한 세션 수: {result['user_progress']['completed_session_count']}")
+    col_a, col_b = st.columns(2)
+    if col_a.button("새 세션 시작", type="primary"):
+        reset_session_progress()
+        st.rerun()
+    if col_b.button("종료"):
+        reset_session_progress()
+        st.rerun()
+
+
+def main() -> None:
+    st.set_page_config(page_title=f"{SERVICE_NAME} MVP", page_icon="🧭", layout="wide")
+    ensure_state()
+    render_sidebar()
+
+    if resolve_content_path() is None:
+        st.warning(
+            "콘텐츠 파일을 찾지 못했습니다. 다음 경로를 확인하세요: "
+            + ", ".join(str(path) for path in CONTENT_CANDIDATE_PATHS)
         )
 
-        evaluation = {
-            "evaluation_type": "rubric",
-            "rubric_result": rubric_result,
-            "feedback": feedback
-        }
-
-    # Update session state
-    session_state["session_score"] += earned_score
-    session_state["answers"].append({
-        "answer_id": f"ans_{len(session_state['answers']) + 1}",
-        "session_id": session_state["session_id"],
-        "quest_id": quest_id,
-        "user_response": user_response,
-        "evaluation": evaluation,
-        "earned_score": earned_score
-    })
-
-    is_session_complete = (session_state["current_quest_index"] + 1) == len(session_state["quests"])
-
-    return {
-        "answer_id": f"ans_{len(session_state['answers'])}",
-        "evaluation": evaluation,
-        "earned_score": earned_score,
-        "is_session_complete": is_session_complete
-    }
-
-def api_session_result() -> Dict[str, Any]:
-    session_state = st.session_state.session_state
-    previous_grade = session_state["user_progress"]["current_grade"]
-
-    # Update cumulative score
-    session_state["user_progress"]["cumulative_score"] += session_state["session_score"]
-    session_state["user_progress"]["completed_session_count"] += 1
-
-    # Determine new grade
-    new_grade = determine_grade(session_state["user_progress"]["cumulative_score"])
-    session_state["user_progress"]["current_grade"] = new_grade
-
-    grade_up_event = (new_grade != previous_grade)
-
-    return {
-        "session_id": session_state["session_id"],
-        "session_score": session_state["session_score"],
-        "user_progress": session_state["user_progress"],
-        "grade_up_event": grade_up_event,
-        "previous_grade": previous_grade,
-        "new_grade": new_grade
-    }
-
-# Main app
-
-def main():
-    st.title("📚 질문력 퀘스트")
-
-    if st.session_state.session_state["session_id"] is None:
-        # Start screen
-        st.markdown("### 오늘의 질문력 퀘스트")
-        st.write("3개의 퀘스트를 풀고 질문력 점수를 쌓아보세요!")
-        col1, col2 = st.columns(2)
-        with col1:
-            st.metric("누적 점수", st.session_state.session_state["user_progress"]["cumulative_score"])
-        with col2:
-            st.metric("현재 등급", st.session_state.session_state["user_progress"]["current_grade"])
-
-        if st.button("세션 시작"):
-            api_session_start()
-            st.experimental_rerun()
+    screen = st.session_state.current_screen
+    if screen == SCREEN_START:
+        render_start_screen()
+    elif screen == SCREEN_MULTIPLE_CHOICE:
+        render_multiple_choice_screen()
+    elif screen == SCREEN_MULTIPLE_CHOICE_RESULT:
+        render_multiple_choice_result()
+    elif screen == SCREEN_IMPROVEMENT:
+        render_improvement_screen()
+    elif screen == SCREEN_IMPROVEMENT_RESULT:
+        render_improvement_result()
+    elif screen == SCREEN_SESSION_RESULT:
+        render_session_result()
     else:
-        session_state = st.session_state.session_state
-        current_quest_index = session_state["current_quest_index"]
-        quest = session_state["quests"][current_quest_index]
+        st.error(f"알 수 없는 화면 상태입니다: {screen}")
 
-        # Display progress
-        st.markdown(f"### 퀘스트 {current_quest_index + 1} / {len(session_state['quests'])}")
-
-        if quest["quiz_type"] == "multiple_choice":
-            # Multiple choice quest
-            st.markdown(f"#### {quest['title']}")
-            st.write(f"학습 맥락: {quest['topic_context']}")
-            st.write(f"원본 질문: {quest['original_question']}")
-            st.write("이 질문을 더 좋게 바꾼 선택지는 무엇일까요?")
-
-            selected_option = st.radio("", quest["choices"], key=f"option_{current_quest_index}", index=None, help="선택지를 골라주세요")
-
-            if st.button("제출"):
-                if selected_option is None:
-                    st.error("선택지를 골라주세요")
-                else:
-                    response = api_quest_submit(quest, quest["choices"].index(selected_option))
-                    if "error_code" in response:
-                        st.error(response["error_message"])
-                    else:
-                        st.session_state.session_state["current_quest_index"] += 1
-                        st.experimental_rerun()
-        else:
-            # Question improvement quest
-            st.markdown(f"#### {quest['title']}")
-            st.write(f"학습 맥락: {quest['topic_context']}")
-            st.write(f"원본 질문: {quest['original_question']}")
-            st.write("이 질문을 더 명확하게 바꿔보세요. 무엇을, 왜, 어떻게가 들어가면 좋아요.")
-
-            user_response = st.text_area("", key=f"response_{current_quest_index}", height=100)
-            st.write(f"{len(user_response)} / 300")
-
-            if st.button("제출"):
-                if not user_response.strip():
-                    st.error("질문을 작성해주세요")
-                elif len(user_response.strip()) < 10:
-                    st.error("조금 더 자세히 작성해주세요 (최소 10자)")
-                else:
-                    response = api_quest_submit(quest, user_response)
-                    if "error_code" in response:
-                        st.error(response["error_message"])
-                    else:
-                        st.session_state.session_state["current_quest_index"] += 1
-                        st.experimental_rerun()
-
-        # Check if session is complete
-        if session_state["current_quest_index"] >= len(session_state["quests"]):
-            result = api_session_result()
-            st.markdown("### 🎉 오늘의 퀘스트 완료!")
-            st.write(f"이번 세션: +{result['session_score']}점")
-            st.write(f"전체 누적: {result['user_progress']['cumulative_score']}점")
-            st.write(f"현재 등급: {result['user_progress']['current_grade']}")
-
-            if result["grade_up_event"]:
-                st.success(f"축하해요! 이제 {result['new_grade']} 단계예요")
-
-            if st.button("새 세션 시작"):
-                st.session_state.session_state = {
-                    "session_id": None,
-                    "quests": [],
-                    "current_quest_index": 0,
-                    "user_progress": result["user_progress"],
-                    "session_score": 0,
-                    "answers": []
-                }
-                st.experimental_rerun()
-
-            if st.button("종료"):
-                st.session_state.session_state = {
-                    "session_id": None,
-                    "quests": [],
-                    "current_quest_index": 0,
-                    "user_progress": result["user_progress"],
-                    "session_score": 0,
-                    "answers": []
-                }
-                st.experimental_rerun()
 
 if __name__ == "__main__":
     main()

--- a/orchestrator/app_source.py
+++ b/orchestrator/app_source.py
@@ -309,40 +309,69 @@ def _build_quest_streamlit_app_source(
                 return GRADE_LEVELS[0] if GRADE_LEVELS else ""
 
 
-            def normalize_quest(item: dict[str, Any], difficulty: str) -> dict[str, Any]:
-                quest = dict(item)
-                quest.setdefault("difficulty", difficulty)
-                quest.setdefault("topic_context", quest.get("learning_dimension") or SERVICE_NAME)
-                quest.setdefault("original_question", quest.get("question") or "질문을 더 좋게 만들어 보세요.")
-                quest.setdefault("options", list(quest.get("choices", [])))
-                if quest.get("correct_choice") in quest.get("options", []):
-                    quest.setdefault("correct_option_index", quest["options"].index(quest["correct_choice"]))
-                else:
-                    quest.setdefault("correct_option_index", None)
-                return quest
+            def normalize_quest(item: dict[str, Any]) -> dict[str, Any]:
+                quiz_type = str(item.get("quiz_type") or "")
+                inferred_difficulty = "intro" if quiz_type == "multiple_choice" else "main"
+                options = list(item.get("choices", []))
+                correct_option_text = item.get("correct_choice")
+                correct_option_index = (
+                    options.index(correct_option_text) if correct_option_text in options else None
+                )
+                question = item.get("question") or "질문을 더 좋게 만들어 보세요."
+                return {
+                    "quest_id": str(item.get("item_id") or uuid4()),
+                    "quest_type": quiz_type,
+                    "difficulty": item.get("difficulty") or inferred_difficulty,
+                    "topic_context": item.get("topic_context") or item.get("learning_dimension") or SERVICE_NAME,
+                    "title": item.get("title") or question,
+                    "question": question,
+                    "original_question": item.get("original_question") or question,
+                    "options": options,
+                    "correct_option_text": correct_option_text,
+                    "correct_option_index": correct_option_index,
+                    "explanation": item.get("explanation") or "",
+                    "learning_point": item.get("learning_point") or "",
+                }
 
 
             def build_session_quests(data: dict[str, Any]) -> list[dict[str, Any]]:
-                items = list(data.get("items", []))
+                normalized = [normalize_quest(item) for item in data.get("items", [])]
+                intro_candidates = [
+                    quest
+                    for quest in normalized
+                    if quest.get("difficulty") == "intro"
+                    and quest.get("quest_type") == "multiple_choice"
+                ]
+                main_candidates = [
+                    quest
+                    for quest in normalized
+                    if quest.get("difficulty") == "main"
+                    and quest.get("quest_type") == "question_improvement"
+                ]
+                if intro_candidates and len(main_candidates) >= 2:
+                    return [intro_candidates[0], main_candidates[0], main_candidates[1]]
+
                 multiple_choice = [
-                    normalize_quest(item, "intro")
-                    for item in items
-                    if item.get("quiz_type") == "multiple_choice"
+                    quest for quest in normalized if quest.get("quest_type") == "multiple_choice"
                 ]
                 question_improvement = [
-                    normalize_quest(item, "main")
-                    for item in items
-                    if item.get("quiz_type") == "question_improvement"
+                    quest
+                    for quest in normalized
+                    if quest.get("quest_type") == "question_improvement"
                 ]
-                if len(multiple_choice) < 1 or len(question_improvement) < 2:
-                    raise ValueError(
-                        "세션을 구성하려면 multiple_choice 1개와 question_improvement 2개가 필요합니다."
-                    )
-                return [
-                    multiple_choice[0],
-                    question_improvement[0],
-                    question_improvement[1],
-                ]
+                if len(multiple_choice) >= 1 and len(question_improvement) >= 2:
+                    return [multiple_choice[0], question_improvement[0], question_improvement[1]]
+
+                raise ValueError(
+                    "퀘스트를 불러오지 못했어요. multiple_choice 1개와 question_improvement 2개가 필요합니다."
+                )
+
+
+            def screen_for_quest(quest: dict[str, Any], *, feedback: bool = False) -> str:
+                quest_type = quest.get("quest_type")
+                if quest_type == "multiple_choice":
+                    return SCREEN_MULTIPLE_CHOICE_RESULT if feedback else SCREEN_MULTIPLE_CHOICE
+                return SCREEN_IMPROVEMENT_RESULT if feedback else SCREEN_IMPROVEMENT
 
 
             def calculate_multiple_choice_score(is_correct: bool) -> int:
@@ -472,7 +501,7 @@ def _build_quest_streamlit_app_source(
                 st.session_state.session_finalized = False
                 st.session_state.grade_up_event = None
                 st.session_state.last_api_response = response
-                st.session_state.current_screen = SCREEN_MULTIPLE_CHOICE
+                st.session_state.current_screen = screen_for_quest(session_quests[0])
                 return response
 
 
@@ -482,8 +511,11 @@ def _build_quest_streamlit_app_source(
                     st.session_state.current_quest_index == len(st.session_state.session_quests) - 1
                 )
 
-                if quest.get("quiz_type") == "multiple_choice":
-                    is_correct = user_response == quest.get("correct_choice")
+                if quest.get("quest_type") == "multiple_choice":
+                    if not isinstance(user_response, str) or user_response not in quest.get("options", []):
+                        return {"error_code": "E_NO_SELECTION", "error_message": "선택지를 골라주세요"}
+
+                    is_correct = user_response == quest.get("correct_option_text")
                     earned_score = calculate_multiple_choice_score(is_correct)
                     response = {
                         "answer_id": str(uuid4()),
@@ -496,8 +528,15 @@ def _build_quest_streamlit_app_source(
                         "correct_option_index": quest.get("correct_option_index"),
                         "is_session_complete": is_session_complete,
                     }
-                    st.session_state.current_screen = SCREEN_MULTIPLE_CHOICE_RESULT
                 else:
+                    if not isinstance(user_response, str) or not user_response.strip():
+                        return {"error_code": "E_EMPTY_INPUT", "error_message": "질문을 작성해주세요"}
+                    if len(user_response.strip()) < IMPROVEMENT_MIN_LENGTH:
+                        return {
+                            "error_code": "E_TOO_SHORT",
+                            "error_message": "조금 더 자세히 작성해주세요 (최소 10자)",
+                        }
+
                     rubric = evaluate_improvement_response(str(user_response))
                     overall = rubric["overall"]
                     earned_score = calculate_improvement_score(overall)
@@ -511,12 +550,12 @@ def _build_quest_streamlit_app_source(
                         "earned_score": earned_score,
                         "is_session_complete": is_session_complete,
                     }
-                    st.session_state.current_screen = SCREEN_IMPROVEMENT_RESULT
 
                 st.session_state.session_score += int(response["earned_score"])
                 st.session_state.last_result = response
-                st.session_state.last_submission = str(user_response)
+                st.session_state.last_submission = user_response
                 st.session_state.last_api_response = response
+                st.session_state.current_screen = screen_for_quest(quest, feedback=True)
                 return response
 
 
@@ -601,14 +640,14 @@ def _build_quest_streamlit_app_source(
                 st.write(f"학습 맥락: {quest.get('topic_context') or SERVICE_NAME}")
                 st.write(f"원본 질문: {quest.get('original_question') or quest.get('question')}")
                 st.info(quest.get("question") or "이 질문을 더 좋게 바꾼 선택지를 골라보세요.")
-                choice_key = f"choice_{quest['item_id']}"
+                choice_key = f"choice_{quest['quest_id']}"
                 st.radio("선택지를 고르세요.", quest.get("options", []), index=None, key=choice_key)
                 if st.button("제출", type="primary"):
                     selected = st.session_state.get(choice_key)
-                    if not selected:
-                        st.warning("선택지를 골라주세요.")
+                    response = api_quest_submit(selected)
+                    if "error_code" in response:
+                        st.warning(response["error_message"])
                     else:
-                        api_quest_submit(selected)
                         st.rerun()
 
 
@@ -620,14 +659,17 @@ def _build_quest_streamlit_app_source(
                 st.subheader("객관식 결과")
                 st.success("정답입니다!" if is_correct else "이 질문도 좋아요")
                 st.write(f"내가 고른 답: {st.session_state.last_submission or '미응답'}")
-                st.write(f"정답: {quest.get('correct_choice', '-')}")
+                st.write(f"정답: {quest.get('correct_option_text', '-')}")
                 st.write(f"해설: {evaluation.get('feedback', quest.get('explanation', ''))}")
+                if quest.get("learning_point"):
+                    st.write(f"학습 포인트: {quest['learning_point']}")
                 st.write(f"획득 점수: +{result.get('earned_score', 0)}점")
                 if st.button("다음 퀘스트로", type="primary"):
                     st.session_state.current_quest_index += 1
                     st.session_state.last_result = None
                     st.session_state.last_submission = ""
-                    st.session_state.current_screen = SCREEN_IMPROVEMENT
+                    next_quest = st.session_state.session_quests[st.session_state.current_quest_index]
+                    st.session_state.current_screen = screen_for_quest(next_quest)
                     st.rerun()
 
 
@@ -638,7 +680,7 @@ def _build_quest_streamlit_app_source(
                 st.write(f"학습 맥락: {quest.get('topic_context') or SERVICE_NAME}")
                 st.write(f"원본 질문: {quest.get('original_question') or quest.get('question')}")
                 st.info("이 질문을 더 명확하게 바꿔보세요. 무엇을, 왜, 어떻게가 들어가면 좋아요.")
-                text_key = f"text_{quest['item_id']}"
+                text_key = f"text_{quest['quest_id']}"
                 user_text = st.text_area(
                     "질문 다시 쓰기",
                     key=text_key,
@@ -647,12 +689,10 @@ def _build_quest_streamlit_app_source(
                 )
                 st.caption(f"{len(user_text)} / {IMPROVEMENT_MAX_LENGTH}")
                 if st.button("제출", type="primary"):
-                    if not user_text.strip():
-                        st.warning("질문을 작성해주세요.")
-                    elif len(user_text.strip()) < IMPROVEMENT_MIN_LENGTH:
-                        st.warning("조금 더 자세히 작성해주세요 (최소 10자).")
+                    response = api_quest_submit(user_text.strip())
+                    if "error_code" in response:
+                        st.warning(response["error_message"])
                     else:
-                        api_quest_submit(user_text.strip())
                         st.rerun()
 
 
@@ -684,6 +724,8 @@ def _build_quest_streamlit_app_source(
                     )
                 )
                 st.write(f"피드백: {evaluation.get('feedback', '')}")
+                if quest.get("learning_point"):
+                    st.write(f"학습 포인트: {quest['learning_point']}")
                 st.write(f"획득 점수: +{result.get('earned_score', 0)}점")
                 button_label = (
                     "결과 보기"
@@ -698,11 +740,7 @@ def _build_quest_streamlit_app_source(
                     else:
                         st.session_state.current_quest_index += 1
                         next_quest = st.session_state.session_quests[st.session_state.current_quest_index]
-                        st.session_state.current_screen = (
-                            SCREEN_MULTIPLE_CHOICE
-                            if next_quest.get("quiz_type") == "multiple_choice"
-                            else SCREEN_IMPROVEMENT
-                        )
+                        st.session_state.current_screen = screen_for_quest(next_quest)
                     st.rerun()
 
 

--- a/prompts/implementation/prototype_builder.md
+++ b/prompts/implementation/prototype_builder.md
@@ -45,8 +45,13 @@ prompt_spec:
   - 콘텐츠 파일이 없으면 `st.warning(...)` 또는 `st.error(...)`로 사용자에게 안내해야 한다.
 - 금지: `CONTENT_PATH = "{content_filename}"`를 먼저 검사한 뒤 `outputs/{content_filename}`를 fallback으로 읽는 root-first 로딩 구조.
 - app.py 실행 시 planning package 파일(interface_spec.md, state_machine.md, data_schema.json, prompt_spec.md, constitution.md)을 다시 읽으면 안 된다.
+- 세션 런타임 quest는 `quest_id`, `quest_type`, `difficulty`, `topic_context`, `original_question`, `options` 필드를 기준으로 동작해야 한다.
+- raw 콘텐츠 필드 `item_id`, `choices`는 정규화 단계에서만 사용하고, 제출/결과 화면 로직에서 직접 참조하지 않는다.
 - `streamlit` 앱에서 사용자는 문제 풀이, 정답 확인, 해설과 학습 포인트 확인이 가능해야 한다.
 - planning package 입력이면 interface_spec의 S0~S5, state_machine의 세션 흐름, data_schema의 score/grade 규칙, prompt_spec의 평가 의도를 반영한다.
+- Streamlit 재실행 API는 `st.rerun()`만 사용한다. `st.experimental_rerun()`은 사용하지 않는다.
+- `current_screen` 기반 상태 머신으로 `S0`, `S1`, `S2`, `S3`, `S4`, `S5`를 구현한다.
+- 제출 직후 바로 다음 문제로 이동하지 말고, 반드시 `S2` 또는 `S4` feedback screen을 거친다.
 - 개선형 퀘스트 평가는 LLM 호출 없이 글자 수, 맥락 키워드, 목적 키워드 기반 규칙으로 처리한다.
 - 개선형 평가 함수와 호출부의 인자 수는 반드시 일치해야 한다.
   - 예: `evaluate_improvement_question(user_response, original_question, topic_context)`로 정의했다면 호출도 3개 인자만 넘긴다.

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -687,6 +687,12 @@ APP_DIR = Path(__file__).resolve().parent
 OUTPUT_PATH = APP_DIR / "outputs" / CONTENT_FILENAME
 FALLBACK_OUTPUT_PATH = APP_DIR / CONTENT_FILENAME
 CONTENT_CANDIDATE_PATHS = [OUTPUT_PATH, FALLBACK_OUTPUT_PATH]
+SCREEN_START = "S0"
+SCREEN_MULTIPLE_CHOICE = "S1"
+SCREEN_MULTIPLE_CHOICE_RESULT = "S2"
+SCREEN_IMPROVEMENT = "S3"
+SCREEN_IMPROVEMENT_RESULT = "S4"
+SCREEN_SESSION_RESULT = "S5"
 
 
 def resolve_content_path() -> Path | None:
@@ -703,12 +709,58 @@ def load_contents() -> dict[str, Any]:
     return json.loads(content_path.read_text(encoding="utf-8"))
 
 
+def ensure_state() -> None:
+    st.session_state.setdefault("current_screen", SCREEN_START)
+    st.session_state.setdefault("session_quests", [])
+    st.session_state.setdefault("current_quest_index", 0)
+    st.session_state.setdefault("last_result", None)
+    st.session_state.setdefault("last_submission", "")
+
+
+def normalize_quest(item: dict[str, Any]) -> dict[str, Any]:
+    options = list(item.get("choices", []))
+    correct_option_text = item.get("correct_choice")
+    correct_option_index = options.index(correct_option_text) if correct_option_text in options else None
+    return {{
+        "quest_id": item.get("item_id", "item-1"),
+        "quest_type": item.get("quiz_type", "multiple_choice"),
+        "difficulty": item.get("difficulty", "intro"),
+        "title": item.get("title", "LLM Generated Item"),
+        "question": item.get("question", ""),
+        "original_question": item.get("original_question", item.get("question", "")),
+        "topic_context": item.get("topic_context", "학습 맥락"),
+        "options": options,
+        "correct_option_text": correct_option_text,
+        "correct_option_index": correct_option_index,
+        "explanation": item.get("explanation", ""),
+        "learning_point": item.get("learning_point", ""),
+    }}
+
+
+def build_session_quests(data: dict[str, Any]) -> list[dict[str, Any]]:
+    items = [normalize_quest(item) for item in data.get("items", [])[:3]]
+    return items
+
+
+def screen_for_quest(quest: dict[str, Any], *, feedback: bool = False) -> str:
+    if quest.get("quest_type") == "multiple_choice":
+        return SCREEN_MULTIPLE_CHOICE_RESULT if feedback else SCREEN_MULTIPLE_CHOICE
+    return SCREEN_IMPROVEMENT_RESULT if feedback else SCREEN_IMPROVEMENT
+
+
 def api_session_start() -> dict[str, Any]:
     data = load_contents()
-    return {{"session_id": "fake-session", "quests": data.get("items", [])[:3]}}
+    quests = build_session_quests(data)
+    st.session_state.session_quests = quests
+    st.session_state.current_quest_index = 0
+    st.session_state.current_screen = screen_for_quest(quests[0]) if quests else SCREEN_START
+    return {{"session_id": "fake-session", "quests": quests}}
 
 
 def api_quest_submit(user_response: Any) -> dict[str, Any]:
+    quest = st.session_state.session_quests[st.session_state.current_quest_index]
+    st.session_state.last_submission = user_response
+    st.session_state.current_screen = screen_for_quest(quest, feedback=True)
     return {{
         "answer_id": "fake-answer",
         "evaluation": {{"evaluation_type": "correctness", "feedback": "테스트 응답입니다."}},
@@ -722,17 +774,56 @@ def api_session_result() -> dict[str, Any]:
     return {{"session_score": 0, "current_grade": "bronze"}}
 
 
+def render_multiple_choice_screen() -> None:
+    quest = st.session_state.session_quests[st.session_state.current_quest_index]
+    st.write(quest.get("question", ""))
+    choice_key = f"choice_{{quest['quest_id']}}"
+    st.radio("선택지를 고르세요.", quest.get("options", []), index=None, key=choice_key)
+    if st.button("제출", key="submit_mc"):
+        selected = st.session_state.get(choice_key)
+        if selected:
+            api_quest_submit(selected)
+            st.rerun()
+
+
+def render_multiple_choice_result() -> None:
+    st.write("객관식 결과")
+
+
+def render_improvement_screen() -> None:
+    quest = st.session_state.session_quests[st.session_state.current_quest_index]
+    st.write(quest.get("question", ""))
+    text_key = f"text_{{quest['quest_id']}}"
+    user_text = st.text_area("질문 다시 쓰기", key=text_key)
+    if st.button("제출", key="submit_improvement") and user_text.strip():
+        api_quest_submit(user_text.strip())
+        st.rerun()
+
+
+def render_improvement_result() -> None:
+    st.write("개선형 결과")
+
+
 def main() -> None:
     st.set_page_config(page_title="LLM Generated MVP", layout="wide")
+    ensure_state()
     st.title("LLM Generated MVP")
     data = load_contents()
     if not data:
         st.warning("콘텐츠 파일을 찾지 못했습니다.")
         return
-    st.write(f"총 {{len(data.get('items', []))}}개 콘텐츠를 읽었습니다.")
-    for item in data.get("items", []):
-        st.markdown(f"### {{item.get('title', item.get('item_id', 'item'))}}")
-        st.write(item.get("question", ""))
+    if not st.session_state.session_quests:
+        api_session_start()
+    if st.session_state.current_screen == SCREEN_MULTIPLE_CHOICE:
+        render_multiple_choice_screen()
+    elif st.session_state.current_screen == SCREEN_MULTIPLE_CHOICE_RESULT:
+        render_multiple_choice_result()
+    elif st.session_state.current_screen == SCREEN_IMPROVEMENT:
+        render_improvement_screen()
+    elif st.session_state.current_screen == SCREEN_IMPROVEMENT_RESULT:
+        render_improvement_result()
+    else:
+        st.write(f"총 {{len(data.get('items', []))}}개 콘텐츠를 읽었습니다.")
 
 
 main()

--- a/tests/test_prototype_builder_agent.py
+++ b/tests/test_prototype_builder_agent.py
@@ -28,6 +28,10 @@ def _build_package_content_output(fake: FakeLLMClient, service_name: str) -> Con
     return fake.generate_json(prompt=prompt, response_model=ContentInteractionOutput)
 
 
+def _extract_function_block(source: str, name: str, next_name: str) -> str:
+    return source.split(f"def {name}", 1)[1].split(f"def {next_name}", 1)[0]
+
+
 def test_prototype_builder_materializes_llm_generated_app_from_planning_package() -> None:
     fake = FakeLLMClient()
     package = load_planning_package(PACKAGE_DIR)
@@ -60,8 +64,22 @@ def test_prototype_builder_materializes_llm_generated_app_from_planning_package(
     assert "question_quest_contents.json" in source
     assert "OUTPUT_PATH = APP_DIR / \"outputs\" / CONTENT_FILENAME" in source
     assert "CONTENT_CANDIDATE_PATHS = [OUTPUT_PATH, FALLBACK_OUTPUT_PATH]" in source
+    assert "current_screen" in source
+    assert "SCREEN_MULTIPLE_CHOICE_RESULT" in source
+    assert "SCREEN_IMPROVEMENT_RESULT" in source
+    assert "st.rerun()" in source
+    assert "st.experimental_rerun" not in source
     assert "load_planning_package" not in source
     assert "constitution.md" not in source
+
+    submit_block = _extract_function_block(
+        source,
+        "api_quest_submit(user_response: Any) -> dict[str, Any]:",
+        "api_session_result() -> dict[str, Any]:",
+    )
+    assert 'quest["choices"]' not in submit_block
+    assert 'quest.get("choices"' not in submit_block
+    assert 'quest["item_id"]' not in submit_block
 
     prompt = fake.prompts[-1]
     assert "# Interface Spec" in prompt
@@ -71,6 +89,9 @@ def test_prototype_builder_materializes_llm_generated_app_from_planning_package(
     assert "prompt_spec" in prompt
     assert "target_framework: streamlit" in prompt
     assert package.service_meta.purpose[:20] in prompt
+    assert "quest_id" in prompt
+    assert "current_screen" in prompt
+    assert "st.rerun()" in prompt
 
 
 def test_prototype_builder_uses_fallback_when_llm_call_fails() -> None:
@@ -175,6 +196,9 @@ APP_DIR = Path(__file__).resolve().parent
 OUTPUT_PATH = APP_DIR / "outputs" / CONTENT_FILENAME
 FALLBACK_OUTPUT_PATH = APP_DIR / CONTENT_FILENAME
 CONTENT_CANDIDATE_PATHS = [OUTPUT_PATH, FALLBACK_OUTPUT_PATH]
+SCREEN_MULTIPLE_CHOICE_RESULT = "S2"
+SCREEN_IMPROVEMENT_RESULT = "S4"
+current_screen = "S3"
 
 
 def resolve_content_path() -> Path | None:
@@ -194,8 +218,12 @@ def api_session_start() -> dict[str, Any]:
 
 def api_quest_submit(user_response: Any) -> dict[str, Any]:
     quest = {
+        "quest_id": "quest-1",
+        "quest_type": "question_improvement",
+        "difficulty": "main",
         "original_question": "이거 뭐야?",
         "topic_context": "국어 숙제",
+        "options": [],
         "desired_answer_form": "예시",
     }
     evaluate_improvement_question(
@@ -211,10 +239,26 @@ def api_session_result() -> dict[str, Any]:
     return {}
 
 
+def render_multiple_choice_screen() -> None:
+    st.write("mc")
+
+
+def render_multiple_choice_result() -> None:
+    st.write("mc-result")
+
+
+def render_improvement_screen() -> None:
+    st.write("improve")
+
+
+def render_improvement_result() -> None:
+    st.write("improve-result")
+
+
 def main() -> None:
     if resolve_content_path() is None:
         st.warning("콘텐츠 파일을 찾지 못했습니다.")
-    st.write("demo")
+    st.rerun()
 
 
 main()
@@ -240,6 +284,94 @@ main()
     assert output.fallback_used is True
     assert "LLM_OUTPUT_INVALID" in output.builder_errors
     assert "evaluate_improvement_question call passes 4 positional args" in output.fallback_reason
+
+
+def test_prototype_builder_rejects_raw_content_fields_in_submit_flow() -> None:
+    raw_field_source = '''from pathlib import Path
+from typing import Any
+
+import streamlit as st
+
+CONTENT_FILENAME = "question_quest_contents.json"
+APP_DIR = Path(__file__).resolve().parent
+OUTPUT_PATH = APP_DIR / "outputs" / CONTENT_FILENAME
+FALLBACK_OUTPUT_PATH = APP_DIR / CONTENT_FILENAME
+CONTENT_CANDIDATE_PATHS = [OUTPUT_PATH, FALLBACK_OUTPUT_PATH]
+SCREEN_MULTIPLE_CHOICE_RESULT = "S2"
+SCREEN_IMPROVEMENT_RESULT = "S4"
+current_screen = "S1"
+
+
+def resolve_content_path() -> Path | None:
+    for candidate in CONTENT_CANDIDATE_PATHS:
+        if candidate.exists():
+            return candidate
+    return None
+
+
+def api_session_start() -> dict[str, Any]:
+    return {"quests": []}
+
+
+def api_quest_submit(user_response: Any) -> dict[str, Any]:
+    quest = {"choices": ["A", "B"], "correct_choice": "A"}
+    if user_response == quest["choices"][0]:
+        st.session_state.current_screen = SCREEN_MULTIPLE_CHOICE_RESULT
+    else:
+        st.session_state.current_screen = SCREEN_IMPROVEMENT_RESULT
+    return {"ok": True}
+
+
+def api_session_result() -> dict[str, Any]:
+    return {}
+
+
+def render_multiple_choice_screen() -> None:
+    quest = {"item_id": "item-1", "options": ["A", "B"]}
+    st.write(quest["item_id"])
+
+
+def render_multiple_choice_result() -> None:
+    st.write("result")
+
+
+def render_improvement_screen() -> None:
+    st.write("improve")
+
+
+def render_improvement_result() -> None:
+    st.write("feedback")
+
+
+def main() -> None:
+    if resolve_content_path() is None:
+        st.warning("콘텐츠 파일을 찾지 못했습니다.")
+    st.rerun()
+
+
+main()
+'''
+    fake = FakeLLMClient(app_source=raw_field_source)
+    package = load_planning_package(PACKAGE_DIR)
+    spec = planning_package_to_implementation_spec(package, PACKAGE_DIR)
+
+    output = run_prototype_builder_agent(
+        PrototypeBuilderInput(
+            spec_intake_output=fake.generate_json(prompt="", response_model=SpecIntakeOutput),
+            requirement_mapping_output=fake.generate_json(
+                prompt="",
+                response_model=RequirementMappingOutput,
+            ),
+            content_interaction_output=_build_package_content_output(fake, spec.service_name),
+            implementation_spec=spec,
+        ),
+        fake,
+    )
+
+    assert output.generation_mode == "fallback_template"
+    assert output.fallback_used is True
+    assert "LLM_OUTPUT_INVALID" in output.builder_errors
+    assert "normalized quest fields only" in output.fallback_reason
 
 
 def test_prototype_builder_returns_unsupported_output_for_react() -> None:

--- a/tests/test_streamlit_mvp.py
+++ b/tests/test_streamlit_mvp.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import ast
+import importlib.util
 import json
 import subprocess
 import sys
@@ -18,6 +19,15 @@ from tests.fakes import FakeLLMClient
 
 
 REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def _load_root_app_module():
+    spec = importlib.util.spec_from_file_location("root_app_module", REPO_ROOT / "app.py")
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
 
 
 def _assert_streamlit_app_starts(app_path: Path, *, cwd: Path, port: int) -> None:
@@ -218,3 +228,71 @@ def test_root_app_improvement_evaluator_call_arity_matches_definition() -> None:
         if node.func.id != "evaluate_improvement_question":
             continue
         assert len(node.args) <= max_positional_args
+
+
+def test_root_app_normalizes_quest_shape_and_falls_back_without_difficulty() -> None:
+    module = _load_root_app_module()
+    data = {
+        "items": [
+            {
+                "item_id": "mc-1",
+                "quiz_type": "multiple_choice",
+                "title": "더 좋은 질문 고르기",
+                "question": "이 질문을 더 좋게 바꾼 선택지를 골라보세요.",
+                "original_question": "비유가 뭔지 모르겠어.",
+                "topic_context": "국어 숙제",
+                "choices": ["A", "B", "C", "D"],
+                "correct_choice": "B",
+                "explanation": "맥락과 목적이 더 분명한 선택지예요.",
+                "learning_point": "질문에 맥락을 넣어보세요.",
+            },
+            {
+                "item_id": "qi-1",
+                "quiz_type": "question_improvement",
+                "title": "질문 더 좋게 만들기 1",
+                "question": "질문을 더 구체적으로 다시 써보세요.",
+                "original_question": "이거 왜 그래?",
+                "topic_context": "과학 수행평가",
+                "choices": [],
+                "correct_choice": "",
+                "explanation": "상황을 더 밝혀야 해요.",
+                "learning_point": "구체성과 목적성을 함께 드러내세요.",
+            },
+            {
+                "item_id": "qi-2",
+                "quiz_type": "question_improvement",
+                "title": "질문 더 좋게 만들기 2",
+                "question": "질문을 더 명확하게 다시 써보세요.",
+                "original_question": "설명해줘.",
+                "topic_context": "사회 발표 준비",
+                "choices": [],
+                "correct_choice": "",
+                "explanation": "도움이 필요한 이유를 넣어야 해요.",
+                "learning_point": "맥락과 목적을 함께 적어보세요.",
+            },
+        ]
+    }
+
+    quests = module.build_session_quests(data)
+
+    assert [quest["quest_type"] for quest in quests] == [
+        "multiple_choice",
+        "question_improvement",
+        "question_improvement",
+    ]
+    assert quests[0]["quest_id"] == "mc-1"
+    assert quests[0]["options"] == ["A", "B", "C", "D"]
+    assert quests[0]["correct_option_text"] == "B"
+    assert quests[0]["correct_option_index"] == 1
+    assert quests[0]["difficulty"] == "intro"
+    assert quests[1]["difficulty"] == "main"
+    assert quests[2]["difficulty"] == "main"
+
+
+def test_root_app_source_uses_feedback_states_and_modern_rerun() -> None:
+    source = (REPO_ROOT / "app.py").read_text(encoding="utf-8")
+    assert "SCREEN_MULTIPLE_CHOICE_RESULT" in source
+    assert "SCREEN_IMPROVEMENT_RESULT" in source
+    assert "current_screen" in source
+    assert "st.rerun()" in source
+    assert "st.experimental_rerun" not in source


### PR DESCRIPTION
## 요약
- Quest MVP 루트 `app.py`의 세션 퀘스트 shape를 정규화해서 `quest_id/options`와 `item_id/choices` 충돌을 제거했습니다.
- 제출 직후 바로 다음 문제로 넘어가던 흐름을 `current_screen` 기반 상태 머신으로 바꿔 `S2`/`S4` 피드백 화면을 반드시 거치게 했습니다.
- `st.experimental_rerun()`을 `st.rerun()`으로 교체했습니다.
- 같은 문제가 다시 생성되지 않도록 Prototype Builder prompt, Quest 앱 템플릿, Builder validation, fake LLM source, 회귀 테스트를 함께 보강했습니다.

## 주요 변경
- 루트 `app.py`를 normalized quest + feedback screen 구조로 재구성
- `orchestrator/app_source.py` Quest 템플릿을 동일 계약으로 정렬
- `agents/implementation/prototype_builder_agent.py`에 상태 머신/필드 계약 validation 추가
- `prompts/implementation/prototype_builder.md`에 필드명 계약, `st.rerun()`, `current_screen` 요구사항 추가
- `tests/test_prototype_builder_agent.py`, `tests/test_streamlit_mvp.py`, `tests/fakes.py` 회귀 보강

## 검증
- `.venv/bin/python -m pytest -q tests/test_prototype_builder_agent.py tests/test_streamlit_mvp.py`
- `.venv/bin/python -m pytest -q`
- `.venv/bin/python -m py_compile app.py`
- `timeout 10s .venv/bin/python -m streamlit run app.py --server.headless true --server.port 8785`
