### PR TITLE
Issue #37 InteractionUnit 중심 구조로 Content & Interaction Agent를 일반화합니다

### DIFF
--- a/agents/implementation/content_interaction_agent.py
+++ b/agents/implementation/content_interaction_agent.py
@@ -6,12 +6,14 @@ import json
 import re
 from collections import Counter
 from dataclasses import dataclass, field
+from typing import Any
 
 from clients.llm import LLMClient
-from schemas.implementation.common import QuizItem
+from schemas.implementation.common import InteractionUnit, QuizItem
 from schemas.implementation.content_interaction import (
     ContentInteractionInput,
     ContentInteractionOutput,
+    InteractionValidationSummary,
     SemanticValidationItemResult,
     SemanticValidationSummary,
 )
@@ -78,6 +80,37 @@ DIRECT_DIMENSION_HINTS = {
     "맥락성": ["맥락", "상황", "배경", "과목", "시간", "장소"],
     "목적성": ["목적", "도움", "원하는", "예시", "방법", "설명", "알고 싶", "이유"],
 }
+QUIZ_MODE_MARKERS = [
+    "퀴즈",
+    "문항",
+    "객관식",
+    "정답",
+    "점수",
+    "배틀",
+    "quest",
+    "multiple_choice",
+    "question_improvement",
+    "situation_card",
+]
+COACHING_MODE_MARKERS = [
+    "챗봇",
+    "채팅",
+    "질문 입력",
+    "되묻기",
+    "follow_up",
+    "coaching",
+    "diagnosis",
+    "/api/chat",
+    "자유 입력",
+]
+INTERACTION_RESULT_TYPES = {
+    "diagnosis",
+    "feedback",
+    "coaching_feedback",
+    "score_summary",
+    "next_step_guide",
+    "display_content",
+}
 
 
 @dataclass
@@ -98,16 +131,18 @@ def run_content_interaction_agent(
     input_model: ContentInteractionInput,
     llm_client: LLMClient,
 ) -> ContentInteractionOutput:
-    """Generate quiz content and repair semantic mismatches with one regeneration pass."""
+    """Generate educational content plus interaction units with quiz backward compatibility."""
 
     content_types = _resolve_content_types(input_model)
     learning_dimensions = _resolve_learning_dimensions(input_model)
     expected_total = _resolve_expected_total(input_model)
     items_per_type = _resolve_items_per_type(input_model)
+    interaction_mode, interaction_mode_reason = _infer_interaction_mode(input_model)
     target_quiz_type_counts = _resolve_target_quiz_type_counts(
         content_types=content_types,
         expected_total=expected_total,
         items_per_type=items_per_type,
+        interaction_mode=interaction_mode,
     )
     service_name = _resolve_service_name(input_model)
 
@@ -119,34 +154,60 @@ def run_content_interaction_agent(
         learning_goals=json.dumps(learning_dimensions, ensure_ascii=False),
         total_count=expected_total,
         items_per_type=items_per_type,
+        interaction_mode=interaction_mode,
+        interaction_mode_reason=interaction_mode_reason,
     )
     output = llm_client.generate_json(
         prompt=prompt,
         response_model=ContentInteractionOutput,
-        system_prompt="You generate structured educational quiz content and interaction notes as valid JSON.",
+        system_prompt=(
+            "You generate structured educational content and interaction flows as valid JSON. "
+            "Always treat interaction_units as the primary interaction contract."
+        ),
     )
     output.agent = make_label(
         "Content & Interaction Agent",
         "교육 콘텐츠·상호작용 생성 Agent",
     )
 
-    _normalize_structural_contract(output)
-    summary = _repair_and_validate_content(
+    output.interaction_mode = interaction_mode
+    output.interaction_mode_reason = interaction_mode_reason
+    _normalize_interaction_metadata(output)
+
+    if interaction_mode == "quiz":
+        _normalize_structural_contract(output)
+        summary = _repair_and_validate_content(
+            output=output,
+            input_model=input_model,
+            llm_client=llm_client,
+            content_types=content_types,
+            learning_dimensions=learning_dimensions,
+            expected_total=expected_total,
+            target_quiz_type_counts=target_quiz_type_counts,
+        )
+        output.semantic_validation = summary
+        _synchronize_output_maps(output, content_types)
+        output.interaction_units = _synthesize_quiz_interaction_units(output.items)
+        output.evaluation_rules = _build_quiz_evaluation_rules(
+            output=output,
+            expected_total=expected_total,
+        )
+        _validate_content_contract(
+            output=output,
+            content_types=content_types,
+            learning_dimensions=learning_dimensions,
+            expected_total=expected_total,
+        )
+    else:
+        output.semantic_validation = None
+        output.evaluation_rules = _build_non_quiz_evaluation_rules(
+            output=output,
+            learning_dimensions=learning_dimensions,
+        )
+
+    output.interaction_validation = _validate_interaction_units(
         output=output,
-        input_model=input_model,
-        llm_client=llm_client,
-        content_types=content_types,
-        learning_dimensions=learning_dimensions,
-        expected_total=expected_total,
-        target_quiz_type_counts=target_quiz_type_counts,
-    )
-    output.semantic_validation = summary
-    _synchronize_output_maps(output, content_types)
-    _validate_content_contract(
-        output=output,
-        content_types=content_types,
-        learning_dimensions=learning_dimensions,
-        expected_total=expected_total,
+        interaction_mode=interaction_mode,
     )
     return output
 
@@ -186,12 +247,57 @@ def _resolve_service_name(input_model: ContentInteractionInput) -> str:
     return input_model.spec_intake_output.service_summary
 
 
+def _infer_interaction_mode(input_model: ContentInteractionInput) -> tuple[str, str]:
+    implementation_spec = input_model.implementation_spec
+    texts = [
+        input_model.spec_intake_output.service_summary,
+        *(input_model.spec_intake_output.normalized_requirements or []),
+        *(input_model.requirement_mapping_output.implementation_targets or []),
+        *(input_model.requirement_mapping_output.app_constraints or []),
+    ]
+    if implementation_spec is not None:
+        texts.extend(
+            [
+                implementation_spec.service_purpose,
+                *implementation_spec.core_features,
+                *implementation_spec.content_interaction_direction,
+                *implementation_spec.expected_outputs,
+            ]
+        )
+
+    joined = " ".join(texts).lower()
+    quiz_hits = [marker for marker in QUIZ_MODE_MARKERS if marker.lower() in joined]
+    coaching_hits = [marker for marker in COACHING_MODE_MARKERS if marker.lower() in joined]
+
+    if quiz_hits and not coaching_hits:
+        return "quiz", f"quiz markers detected: {', '.join(quiz_hits[:5])}"
+    if coaching_hits and not quiz_hits:
+        return "coaching", f"coaching markers detected: {', '.join(coaching_hits[:5])}"
+    if quiz_hits and coaching_hits:
+        return (
+            "general",
+            "conflicting quiz/coaching markers detected: "
+            f"quiz={', '.join(quiz_hits[:3])}; coaching={', '.join(coaching_hits[:3])}",
+        )
+    return "general", "no decisive quiz/coaching markers detected; using safe neutral general mode"
+
+
+def _normalize_interaction_metadata(output: ContentInteractionOutput) -> None:
+    if not output.flow_notes and output.interaction_notes:
+        output.flow_notes = list(output.interaction_notes)
+    if not output.interaction_notes and output.flow_notes:
+        output.interaction_notes = list(output.flow_notes)
+
+
 def _resolve_target_quiz_type_counts(
     *,
     content_types: list[str],
     expected_total: int,
     items_per_type: int,
+    interaction_mode: str,
 ) -> dict[str, int]:
+    if interaction_mode != "quiz":
+        return {}
     if not content_types:
         return {}
     if len(content_types) == 1:
@@ -335,6 +441,127 @@ def _normalize_structural_contract(output: ContentInteractionOutput) -> None:
             item.topic_context = item.learning_dimension or "학습 맥락"
         if not item.original_question:
             item.original_question = item.question
+
+
+def _synthesize_quiz_interaction_units(items: list[QuizItem]) -> list[InteractionUnit]:
+    units: list[InteractionUnit] = []
+    for item in items:
+        action_type = "free_text_input" if item.quiz_type == "question_improvement" else "multiple_choice"
+        action_unit = InteractionUnit(
+            unit_id=f"{item.item_id}_action",
+            interaction_type=action_type,
+            title=item.title,
+            learner_action=item.question,
+            system_response=item.topic_context or item.learning_dimension,
+            input_format="free_text" if action_type == "free_text_input" else "multiple_choice",
+            feedback_rule=(
+                "사용자 응답 후 정답, 해설, 학습 포인트를 포함한 결과 피드백을 보여 준다."
+            ),
+            learning_dimension=item.learning_dimension,
+            metadata={
+                "source_item_id": item.item_id,
+                "quiz_type": item.quiz_type,
+                "choices": list(item.choices),
+                "correct_choice": item.correct_choice,
+                "difficulty": item.difficulty,
+                "topic_context": item.topic_context,
+                "original_question": item.original_question,
+            },
+        )
+        feedback_unit = InteractionUnit(
+            unit_id=f"{item.item_id}_feedback",
+            interaction_type="feedback",
+            title=f"{item.title} 결과",
+            learner_action="",
+            system_response=item.explanation,
+            input_format="",
+            feedback_rule="정답, 해설, 학습 포인트를 보여 주고 다음 단계로 이동시킨다.",
+            learning_dimension=item.learning_dimension,
+            metadata={
+                "source_item_id": item.item_id,
+                "correct_choice": item.correct_choice,
+                "explanation": item.explanation,
+                "learning_point": item.learning_point,
+                "choices": list(item.choices),
+            },
+        )
+        units.extend([action_unit, feedback_unit])
+
+    summary_unit = InteractionUnit(
+        unit_id="session_summary",
+        interaction_type="score_summary",
+        title="세션 요약",
+        learner_action="",
+        system_response="전체 세션 결과와 학습 포인트를 요약해 보여 준다.",
+        feedback_rule="세션 종료 시 전체 결과를 요약한다.",
+        metadata={"source": "quiz_session"},
+        next_step="END",
+    )
+    units.append(summary_unit)
+
+    for index, unit in enumerate(units):
+        if unit.next_step:
+            continue
+        unit.next_step = units[index + 1].unit_id if index + 1 < len(units) else "END"
+
+    return units
+
+
+def _build_quiz_evaluation_rules(
+    *,
+    output: ContentInteractionOutput,
+    expected_total: int,
+) -> dict[str, Any]:
+    if output.evaluation_rules:
+        merged = dict(output.evaluation_rules)
+        merged.setdefault("mode", "quiz")
+        merged.setdefault("expected_total", expected_total)
+        merged.setdefault("feedback_type", "feedback")
+        return merged
+    return {
+        "mode": "quiz",
+        "expected_total": expected_total,
+        "answer_key_mode": "item_id_to_correct_choice",
+        "score_policy": {
+            "per_item": 1,
+            "total_items": expected_total,
+        },
+        "feedback_type": "feedback",
+        "feedback_policy": "정답, 해설, 학습 포인트를 각 문항 결과에서 제공한다.",
+    }
+
+
+def _build_non_quiz_evaluation_rules(
+    *,
+    output: ContentInteractionOutput,
+    learning_dimensions: list[str],
+) -> dict[str, Any]:
+    if output.evaluation_rules:
+        merged = dict(output.evaluation_rules)
+        merged.setdefault("mode", output.interaction_mode)
+        merged.setdefault("diagnosis_criteria", list(learning_dimensions))
+        merged.setdefault("completion_rule", "next_step가 END에 도달하면 세션을 종료한다.")
+        merged.setdefault(
+            "feedback_types",
+            {
+                "feedback": "정답/해설/결과에 대한 일반 피드백",
+                "coaching_feedback": "사용자 자유 입력을 바탕으로 개선 방향을 제안하는 코칭형 피드백",
+            },
+        )
+        return merged
+    return {
+        "mode": output.interaction_mode,
+        "diagnosis_criteria": list(learning_dimensions),
+        "feedback_policy": (
+            "interaction_units의 learner_action, system_response, feedback_rule을 기준으로 "
+            "진단과 후속 피드백을 제공한다."
+        ),
+        "completion_rule": "next_step가 END에 도달하면 세션을 종료한다.",
+        "feedback_types": {
+            "feedback": "정답/해설/결과에 대한 일반 피드백",
+            "coaching_feedback": "사용자 자유 입력을 바탕으로 개선 방향을 제안하는 코칭형 피드백",
+        },
+    }
 
 
 def _synchronize_output_maps(output: ContentInteractionOutput, content_types: list[str]) -> None:
@@ -853,6 +1080,68 @@ def _build_item_results(
             )
         )
     return results
+
+
+def _validate_interaction_units(
+    *,
+    output: ContentInteractionOutput,
+    interaction_mode: str,
+) -> InteractionValidationSummary:
+    issues: list[str] = []
+    units = output.interaction_units
+
+    if interaction_mode in {"coaching", "general"} and not units:
+        issues.append("interaction_units must not be empty for coaching/general mode.")
+    if interaction_mode == "quiz" and output.items and not units:
+        issues.append("interaction_units must be synthesized or provided for quiz mode.")
+
+    unit_ids = [unit.unit_id for unit in units]
+    duplicate_ids = [unit_id for unit_id, count in Counter(unit_ids).items() if count > 1]
+    if duplicate_ids:
+        issues.append(f"interaction_units contain duplicate unit_id values: {duplicate_ids}.")
+
+    valid_targets = set(unit_ids)
+    for unit in units:
+        if not unit.interaction_type:
+            issues.append(f"{unit.unit_id} is missing interaction_type.")
+        if unit.next_step and unit.next_step != "END" and unit.next_step not in valid_targets:
+            issues.append(
+                f"{unit.unit_id} next_step points to missing unit_id {unit.next_step!r}."
+            )
+        if unit.interaction_type == "multiple_choice":
+            choices = unit.metadata.get("choices")
+            correct_choice = unit.metadata.get("correct_choice")
+            if not isinstance(choices, list) or not choices:
+                issues.append(f"{unit.unit_id} multiple_choice metadata must include choices.")
+            if not isinstance(correct_choice, str) or not correct_choice:
+                issues.append(
+                    f"{unit.unit_id} multiple_choice metadata must include correct_choice."
+                )
+        if unit.interaction_type == "free_text_input" and not (
+            unit.learner_action or unit.input_format
+        ):
+            issues.append(
+                f"{unit.unit_id} free_text_input must describe learner_action or input_format."
+            )
+        if unit.interaction_type in INTERACTION_RESULT_TYPES and not (
+            unit.system_response or unit.metadata
+        ):
+            issues.append(
+                f"{unit.unit_id} {unit.interaction_type} must include system_response or metadata."
+            )
+
+    structure_valid = not issues
+    if not structure_valid:
+        raise ValueError("Interaction-unit validation failed. " + " | ".join(issues))
+
+    return InteractionValidationSummary(
+        interaction_mode=interaction_mode,
+        mode_inference_reason=output.interaction_mode_reason,
+        unit_count=len(units),
+        unit_type_counts=dict(Counter(unit.interaction_type for unit in units)),
+        structure_valid=structure_valid,
+        issues=issues,
+    )
 
 
 def _validate_content_contract(

--- a/agents/implementation/prototype_builder_agent.py
+++ b/agents/implementation/prototype_builder_agent.py
@@ -272,6 +272,14 @@ def _build_app_generation_prompt(
         "state_machine": package_context.get("state_machine", ""),
         "data_schema": package_context.get("data_schema", ""),
         "prompt_spec": package_context.get("prompt_spec", ""),
+        "interaction_mode": input_model.content_interaction_output.interaction_mode,
+        "interaction_mode_reason": input_model.content_interaction_output.interaction_mode_reason,
+        "interaction_units": [
+            unit.model_dump(mode="json")
+            for unit in input_model.content_interaction_output.interaction_units
+        ],
+        "flow_notes": input_model.content_interaction_output.flow_notes,
+        "evaluation_rules": input_model.content_interaction_output.evaluation_rules,
     }
     return prompt_template.format(
         target_framework=context["target_framework"],
@@ -295,6 +303,15 @@ def _build_app_generation_prompt(
         state_machine=context["state_machine"],
         data_schema=context["data_schema"],
         prompt_spec=context["prompt_spec"],
+        interaction_mode=context["interaction_mode"],
+        interaction_mode_reason=context["interaction_mode_reason"],
+        interaction_units=json.dumps(context["interaction_units"], ensure_ascii=False, indent=2),
+        flow_notes=json.dumps(context["flow_notes"], ensure_ascii=False, indent=2),
+        evaluation_rules=json.dumps(
+            context["evaluation_rules"],
+            ensure_ascii=False,
+            indent=2,
+        ),
     )
 
 
@@ -579,6 +596,8 @@ def _build_generation_inputs_summary(input_model: PrototypeBuilderInput) -> list
         f"service_purpose={'present' if spec.service_purpose else 'missing'}",
         f"target_user_count={len(spec.target_users)}",
         f"mvp_scope_count={len(spec.core_features)}",
+        f"interaction_mode={input_model.content_interaction_output.interaction_mode}",
+        f"interaction_unit_count={len(input_model.content_interaction_output.interaction_units)}",
         "spec_intake_output",
         "requirement_mapping_output",
         "content_interaction_output",

--- a/agents/implementation/qa_alignment_agent.py
+++ b/agents/implementation/qa_alignment_agent.py
@@ -17,46 +17,58 @@ def run_qa_alignment_agent(
     _ = load_prompt_text
     _ = dump_model
 
-    item_count = len(input_model.content_interaction_output.items)
-    quiz_type_count = len(input_model.content_interaction_output.quiz_types)
+    content_output = input_model.content_interaction_output
+    item_count = len(content_output.items)
+    quiz_type_count = len(content_output.quiz_types)
+    interaction_mode = content_output.interaction_mode or "quiz"
+    interaction_mode_reason = content_output.interaction_mode_reason or "not provided"
+    interaction_units = content_output.interaction_units
+    interaction_unit_count = len(interaction_units)
+    interaction_validation = content_output.interaction_validation
+    interaction_type_counts = (
+        interaction_validation.unit_type_counts
+        if interaction_validation is not None
+        else {}
+    )
+    interaction_distribution = _describe_interaction_distribution(
+        interaction_type_counts=interaction_type_counts,
+    )
+    quiz_backward_compat = item_count > 0
     implementation_spec = input_model.implementation_spec
     expected_total = implementation_spec.total_count if implementation_spec else item_count
     configured_content_types = (
         implementation_spec.core_features
         if implementation_spec and implementation_spec.core_features
-        else input_model.content_interaction_output.quiz_types
+        else content_output.quiz_types
     )
     expected_quiz_type_count = len(configured_content_types)
     quiz_type_counts = {
-        quiz_type: sum(
-            1 for item in input_model.content_interaction_output.items if item.quiz_type == quiz_type
-        )
+        quiz_type: sum(1 for item in content_output.items if item.quiz_type == quiz_type)
         for quiz_type in configured_content_types
     }
     quest_session_shape = _describe_content_shape(
         configured_content_types=configured_content_types,
         quiz_type_counts=quiz_type_counts,
     )
-    semantic_summary = input_model.content_interaction_output.semantic_validation
+    semantic_summary = content_output.semantic_validation
     issues = list(input_model.run_test_and_fix_output.remaining_risks)
-    if item_count != expected_total:
+    if interaction_validation is None:
+        issues.append("Interaction validation summary is missing from content output.")
+    elif not interaction_validation.structure_valid:
+        issues.append("Interaction-unit structural validation did not fully pass.")
+
+    if interaction_mode == "quiz" and item_count != expected_total:
         issues.append(f"Expected {expected_total} quiz items but found {item_count}.")
-    if quiz_type_count != expected_quiz_type_count:
+    if interaction_mode == "quiz" and quiz_type_count != expected_quiz_type_count:
         issues.append(
             f"Expected {expected_quiz_type_count} configured content types but found {quiz_type_count}."
         )
-    if semantic_summary is None:
+    if interaction_mode == "quiz" and semantic_summary is None:
         issues.append("Semantic validation summary is missing from quiz_contents output.")
 
-    quiz_type_balance_ok = bool(
-        semantic_summary and semantic_summary.quiz_type_distribution_valid
-    )
-    learning_dimension_ok = bool(
-        semantic_summary and semantic_summary.learning_dimension_values_valid
-    )
-    semantic_validator_ok = bool(
-        semantic_summary and semantic_summary.semantic_validator_passed
-    )
+    quiz_type_balance_ok = bool(semantic_summary and semantic_summary.quiz_type_distribution_valid)
+    learning_dimension_ok = bool(semantic_summary and semantic_summary.learning_dimension_values_valid)
+    semantic_validator_ok = bool(semantic_summary and semantic_summary.semantic_validator_passed)
     regeneration_count = semantic_summary.regeneration_count if semantic_summary else 0
     streamlit_smoke_ran = "streamlit_smoke" in input_model.run_test_and_fix_output.checks_run
     streamlit_smoke_failed = any(
@@ -71,11 +83,11 @@ def run_qa_alignment_agent(
     )
     package_pytest_passed = package_pytest_ran and not package_pytest_failed
 
-    if not quiz_type_balance_ok:
+    if interaction_mode == "quiz" and not quiz_type_balance_ok:
         issues.append("Quiz type distribution does not match the configured content shape.")
-    if not learning_dimension_ok:
+    if interaction_mode == "quiz" and not learning_dimension_ok:
         issues.append("One or more learning_dimension values are invalid.")
-    if not semantic_validator_ok:
+    if interaction_mode == "quiz" and not semantic_validator_ok:
         issues.append("Semantic validator did not fully pass.")
     if streamlit_smoke_ran and not streamlit_smoke_passed:
         issues.append("Streamlit smoke test did not pass.")
@@ -93,15 +105,46 @@ def run_qa_alignment_agent(
         ),
         alignment_status="PASS" if not issues else "WARN",
         qa_checklist=[
-            f"총 문제 수 확인: {item_count}",
-            f"세션 구성 확인: {quest_session_shape}",
+            f"interaction_mode 확인: {interaction_mode}",
+            f"interaction_mode 추론 이유: {interaction_mode_reason}",
+            f"interaction_units 수 확인: {interaction_unit_count}",
+            f"interaction_type 분포 확인: {interaction_distribution}",
+            f"QuizItem 하위 호환 사용 여부: {'YES' if quiz_backward_compat else 'NO'}",
+            (
+                f"총 문제 수 확인: {item_count}"
+                if interaction_mode == 'quiz'
+                else "총 문제 수 확인: N/A (interaction-unit primary mode)"
+            ),
+            (
+                f"세션 구성 확인: {quest_session_shape}"
+                if interaction_mode == 'quiz'
+                else "세션 구성 확인: interaction_units 순서와 next_step 기준"
+            ),
             (
                 f"configured content type 수({expected_quiz_type_count}) 일치 여부: "
                 f"{'PASS' if quiz_type_balance_ok else 'FAIL'}"
+                if interaction_mode == "quiz"
+                else "N/A (interaction-unit primary mode)"
             ),
-            f"learning_dimension 허용값 여부: {'PASS' if learning_dimension_ok else 'FAIL'}",
-            f"semantic validator 통과 여부: {'PASS' if semantic_validator_ok else 'FAIL'}",
-            f"재생성 발생 여부: {'YES' if regeneration_count else 'NO'}",
+            (
+                f"learning_dimension 허용값 여부: {'PASS' if learning_dimension_ok else 'FAIL'}"
+                if interaction_mode == "quiz"
+                else "learning_dimension 허용값 여부: N/A (quiz semantic validator not required)"
+            ),
+            (
+                f"semantic validator 통과 여부: {'PASS' if semantic_validator_ok else 'FAIL'}"
+                if interaction_mode == "quiz"
+                else "semantic validator 통과 여부: N/A (interaction-unit primary mode)"
+            ),
+            (
+                f"재생성 발생 여부: {'YES' if regeneration_count else 'NO'}"
+                if interaction_mode == "quiz"
+                else "재생성 발생 여부: N/A (quiz regeneration path not used)"
+            ),
+            (
+                "interaction_units 구조 validator 통과 여부: "
+                f"{'PASS' if interaction_validation and interaction_validation.structure_valid else 'FAIL'}"
+            ),
             (
                 "app.py Streamlit smoke test 여부: "
                 f"{'PASS' if streamlit_smoke_passed else 'FAIL' if streamlit_smoke_ran else 'NOT RUN'}"
@@ -130,6 +173,11 @@ def run_qa_alignment_agent(
                 "실패 시에만 fallback template을 사용하도록 정리되었다."
             ),
             (
+                "Content & Interaction Agent는 InteractionUnit 중심 구조를 함께 생성하며, "
+                f"interaction_mode={interaction_mode}, unit_count={interaction_unit_count}, "
+                f"mode_reason={interaction_mode_reason}."
+            ),
+            (
                 "Prototype Builder generation result: "
                 f"mode={input_model.prototype_builder_output.generation_mode}, "
                 f"fallback_used={input_model.prototype_builder_output.fallback_used}, "
@@ -138,25 +186,40 @@ def run_qa_alignment_agent(
             "QA & Alignment Agent는 현재 단계에서 deterministic summary를 생성한다.",
             (
                 "#12 semantic validator 결과: "
+                f"mode={interaction_mode}, "
                 f"expected_total={expected_total}, "
                 f"actual_total={item_count}, "
                 f"configured_content_types={expected_quiz_type_count}, "
-                f"content_types_valid={quiz_type_balance_ok}, "
-                f"learning_dimension_valid={learning_dimension_ok}, "
-                f"semantic_validator_passed={semantic_validator_ok}, "
-                f"regeneration_count={regeneration_count}, "
+                f"content_types_valid={quiz_type_balance_ok if interaction_mode == 'quiz' else 'N/A'}, "
+                f"learning_dimension_valid={learning_dimension_ok if interaction_mode == 'quiz' else 'N/A'}, "
+                f"semantic_validator_passed={semantic_validator_ok if interaction_mode == 'quiz' else 'N/A'}, "
+                f"regeneration_count={regeneration_count if interaction_mode == 'quiz' else 'N/A'}, "
+                f"interaction_structure_valid={interaction_validation.structure_valid if interaction_validation else False}, "
                 f"streamlit_smoke={'PASS' if streamlit_smoke_passed else 'FAIL' if streamlit_smoke_ran else 'NOT RUN'}, "
                 f"package_pytest={'PASS' if package_pytest_passed else 'FAIL' if package_pytest_ran else 'NOT RUN'}."
             ),
         ],
         final_summary_points=[
             "교육 서비스 구현팀 6-Agent 파이프라인이 실행되었다.",
-            f"{quiz_type_count}개 content type, 총 {item_count}문항이 생성되었다.",
-            f"세션 구성: {quest_session_shape}.",
+            (
+                f"{quiz_type_count}개 content type, 총 {item_count}문항이 생성되었다."
+                if interaction_mode == "quiz"
+                else f"{interaction_unit_count}개 interaction unit이 생성되었다."
+            ),
+            (
+                f"세션 구성: {quest_session_shape}."
+                if interaction_mode == "quiz"
+                else f"상호작용 흐름: {interaction_distribution}."
+            ),
+            f"interaction_mode={interaction_mode}, reason={interaction_mode_reason}.",
             (
                 "#12 검증 결과: "
-                f"semantic validator={'PASS' if semantic_validator_ok else 'FAIL'}, "
-                f"재생성={'없음' if regeneration_count == 0 else f'{regeneration_count}건'}."
+                f"semantic validator="
+                f"{'PASS' if semantic_validator_ok else 'FAIL' if interaction_mode == 'quiz' else 'N/A'}, "
+                f"interaction validator="
+                f"{'PASS' if interaction_validation and interaction_validation.structure_valid else 'FAIL'}, "
+                f"재생성="
+                f"{'없음' if interaction_mode != 'quiz' or regeneration_count == 0 else f'{regeneration_count}건'}."
             ),
             (
                 "#20 실행 검증 결과: "
@@ -186,3 +249,12 @@ def _describe_content_shape(
         for quiz_type in configured_content_types
     ]
     return " + ".join(parts)
+
+
+def _describe_interaction_distribution(*, interaction_type_counts: dict[str, int]) -> str:
+    if not interaction_type_counts:
+        return "interaction_type 없음"
+    return " + ".join(
+        f"{interaction_type} {count}"
+        for interaction_type, count in sorted(interaction_type_counts.items())
+    )

--- a/docs/content_interaction_generalization.md
+++ b/docs/content_interaction_generalization.md
@@ -1,0 +1,112 @@
+# Content & Interaction Generalization
+
+## 목적
+
+Issue #37의 목표는 `Content & Interaction Agent` 출력 구조를 `QuizItem` 중심에서 `InteractionUnit` 중심으로 일반화하는 것이다.
+
+이 변경은 퀴즈형 서비스만 처리하던 구조를 유지하면서도, 챗봇형/코칭형/혼합형 교육 서비스를 같은 파이프라인에서 표현할 수 있게 만들기 위한 것이다.
+
+## 기존 구조의 한계
+
+- 기존 `ContentInteractionOutput`은 `items`, `quiz_types`, `answer_key` 같은 퀴즈형 필드를 중심으로 설계되어 있었다.
+- 이 구조는 객관식 또는 질문 개선형 퀘스트에는 잘 맞지만, 자유 입력, 진단, 되묻기, 코칭 피드백 중심 서비스에는 맞지 않는다.
+- Prototype Builder도 화면 흐름을 문제 단위로만 이해하기 쉬워, 비퀴즈형 상호작용을 표현하기가 어려웠다.
+
+## 새 canonical 구조
+
+이제 `interaction_units`를 모든 서비스의 primary contract로 둔다.
+
+각 `InteractionUnit`은 다음 정보를 가진다.
+
+- `unit_id`
+- `interaction_type`
+- `title`
+- `learner_action`
+- `system_response`
+- `input_format`
+- `feedback_rule`
+- `learning_dimension`
+- `next_step`
+- `metadata`
+
+Prototype Builder는 이 구조를 읽어 화면 흐름을 만든다.
+
+- 화면 순서는 `interaction_units` 배열 순서
+- 상태 전이는 `next_step`
+- 입력 방식은 `interaction_type`와 `input_format`
+- 추가 제약은 `metadata`
+
+## QuizItem 하위 호환
+
+기존 질문력 퀘스트 경로는 깨지지 않게 유지한다.
+
+- 퀴즈형 서비스에서는 `items`, `quiz_types`, `answer_key`, `explanations`, `learning_points`를 계속 채운다.
+- 동시에 `items`에서 `interaction_units`를 deterministic하게 합성한다.
+- 따라서 기존 퀴즈 semantic validator와 regeneration 경로는 유지되고, Builder는 같은 출력에서 더 일반적인 상호작용 흐름도 참고할 수 있다.
+
+## interaction_mode
+
+`interaction_mode`는 app 템플릿 선택자가 아니다.
+
+- `quiz`
+- `coaching`
+- `general`
+
+세 값은 생성/검증 전략을 고르는 hint로만 사용한다.
+
+- `quiz`: 기존 `QuizItem` 생성 + semantic validator 유지, `interaction_units`도 함께 생성
+- `coaching`: `interaction_units` 중심, 자유 입력/진단/코칭 피드백 구조
+- `general`: quiz/coaching 어느 한쪽으로 단정하기 어려울 때의 안전한 중립 모드
+
+`general`은 실패 상태가 아니다. mode 추론이 불확실해도 `interaction_units`가 구조 validator를 통과하면 정상 진행한다.
+
+## mode 추론 방식과 한계
+
+mode 추론은 deterministic helper로 수행한다.
+
+- 퀴즈/문항/객관식/정답/점수/quest 성격이 우세하면 `quiz`
+- 챗봇/질문 입력/되묻기/진단/coaching `/api/chat` 성격이 우세하면 `coaching`
+- 신호가 약하거나 충돌하면 `general`
+
+한계:
+
+- 키워드와 spec 요약을 기반으로 한 보수적 추론이라, 복합 서비스는 `general`로 떨어질 수 있다.
+- 이는 의도된 안전장치다. Builder는 `interaction_mode`보다 `interaction_units` 자체를 우선 읽는다.
+
+## feedback 과 coaching_feedback 구분
+
+- `feedback`: 정답/해설/결과에 대한 일반 피드백
+- `coaching_feedback`: 사용자 자유 입력을 바탕으로 개선 방향을 제안하는 코칭형 피드백
+
+즉, 퀴즈 해설 결과는 기본적으로 `feedback`이고, 자유 입력 개선 제안은 `coaching_feedback`이다.
+
+## Prototype Builder 연동
+
+Prototype Builder는 `interaction_units`를 app.py 생성의 primary contract로 받는다.
+
+프롬프트에는 다음을 명시적으로 포함한다.
+
+- `interaction_mode`
+- `interaction_mode_reason`
+- `interaction_units`
+- `flow_notes`
+- `evaluation_rules`
+
+Builder는 여기서:
+
+- 화면 흐름: `interaction_units` 순서와 `next_step`
+- 입력 유형: `interaction_type`, `input_format`
+- 평가/피드백 규칙: `evaluation_rules`
+
+를 우선 사용한다.
+
+## #31에서 이어서 검증할 범위
+
+Issue #37은 구조 일반화와 Builder 연동까지를 다룬다.
+
+다음 검증은 Issue #31 범위다.
+
+- `inputs/260428_챗봇/` 기준 결과 비교
+- `inputs/260429_퀘스트_v2/` 기준 결과 비교
+- service별 live output 의미 정합성 검증
+- app.py가 non-quiz interaction_units를 얼마나 자연스럽게 화면으로 옮기는지 검증

--- a/orchestrator/pipeline.py
+++ b/orchestrator/pipeline.py
@@ -720,6 +720,10 @@ class ImplementationPipeline:
     ) -> None:
         quiz_types = content_output.quiz_types
         total_items = len(content_output.items)
+        interaction_mode = content_output.interaction_mode or "quiz"
+        interaction_reason = content_output.interaction_mode_reason or "not provided"
+        interaction_summary = content_output.interaction_validation
+        interaction_unit_count = len(content_output.interaction_units)
         semantic_summary = content_output.semantic_validation
         streamlit_smoke_ran = "streamlit_smoke" in run_test_and_fix_output.checks_run
         streamlit_smoke_failed = any(
@@ -763,11 +767,20 @@ class ImplementationPipeline:
             [
                 "",
                 "## 콘텐츠 생성 요약",
+                f"- interaction_mode: {interaction_mode}",
+                f"- interaction_mode_reason: {interaction_reason}",
+                f"- interaction_units 수: {interaction_unit_count}",
+                (
+                    "- interaction_type 분포: "
+                    f"{interaction_summary.unit_type_counts if interaction_summary else {}}"
+                ),
+                f"- QuizItem 수: {total_items}",
+                f"- QuizItem 하위 호환 사용 여부: {'YES' if total_items else 'NO'}",
                 f"- 퀴즈 유형 수: {len(quiz_types)}",
-                f"- 총 문제 수: {total_items}",
             ]
         )
-        lines.extend(f"- 유형: {quiz_type}" for quiz_type in quiz_types)
+        if quiz_types:
+            lines.extend(f"- 유형: {quiz_type}" for quiz_type in quiz_types)
         lines.extend(
             [
                 "",
@@ -814,6 +827,26 @@ class ImplementationPipeline:
                     (
                         "- 재생성 발생 여부: "
                         f"{'YES' if semantic_summary.regeneration_requested else 'NO'}"
+                    ),
+                    (
+                        "- app.py Streamlit smoke test 여부: "
+                        f"{'PASS' if streamlit_smoke_ran and not streamlit_smoke_failed else 'FAIL'}"
+                    ),
+                    (
+                        "- package pytest.py 통과 여부: "
+                        f"{'PASS' if package_pytest_ran and not package_pytest_failed else 'FAIL' if package_pytest_ran else 'NOT RUN'}"
+                    ),
+                ]
+            )
+        else:
+            lines.extend(
+                [
+                    "",
+                    "## #12 검증 결과",
+                    "- 총 문항 semantic validator 여부: N/A (interaction-unit primary mode)",
+                    (
+                        "- interaction_units 구조 validator 통과 여부: "
+                        f"{'PASS' if interaction_summary and interaction_summary.structure_valid else 'FAIL'}"
                     ),
                     (
                         "- app.py Streamlit smoke test 여부: "

--- a/prompts/implementation/content_interaction.md
+++ b/prompts/implementation/content_interaction.md
@@ -2,7 +2,7 @@
 
 목표:
 - 교육 서비스용 콘텐츠를 구조화된 JSON으로 생성한다.
-- 지정된 content type과 total count를 만족하는 문제 세트를 만든다.
+- 지정된 content type과 total count를 만족하는 학습 상호작용 구조를 만든다.
 
 명세 요약:
 {spec_intake_output}
@@ -12,17 +12,22 @@
 
 실행 설정:
 - service_name: {service_name}
+- interaction_mode(hint only): {interaction_mode}
+- interaction_mode_reason: {interaction_mode_reason}
 - content_types: {content_types}
 - learning_goals: {learning_goals}
 - total_count: {total_count}
 - items_per_type(reference only): {items_per_type}
 
 반드시 아래를 지켜라:
-- 총 {total_count}문제를 생성한다.
-- 모든 문제는 `quiz_type`, `learning_dimension`, 문제, 선택지, 정답, 해설, 학습 포인트를 포함한다.
-- `quiz_type`은 반드시 `content_types`에 포함된 값만 사용한다.
-- `learning_dimension`은 반드시 `learning_goals`에 포함된 값만 사용한다.
+- `interaction_units`를 모든 서비스의 primary output contract로 생성한다.
+- `interaction_units`는 `unit_id`, `interaction_type`, `learner_action`, `system_response`, `next_step`, `metadata`를 포함해야 한다.
+- `interaction_units`의 순서와 `next_step`이 실제 사용자 흐름이 되도록 작성한다.
+- `interaction_mode`는 템플릿 선택자가 아니라 generation/validation hint다. 확신이 없으면 안전하게 일반화된 interaction flow를 작성한다.
+- quiz 성격이 강한 서비스일 때만 legacy 하위 호환을 위해 `items`, `quiz_types`, `answer_key`, `explanations`, `learning_points`를 함께 채운다.
+- non-quiz 서비스에서는 `interaction_units`, `flow_notes`, `evaluation_rules`를 중심으로 작성하고 legacy quiz 필드는 비워 둘 수 있다.
+- `learning_dimension`은 해설, 진단, 학습 포인트가 실제로 설명하는 질문력 요소와 일치해야 한다.
+- `evaluation_rules`는 퀴즈 정답/점수 규칙뿐 아니라 코칭형 진단 기준, feedback 기준, 완료 조건도 표현할 수 있어야 한다.
 - 중학생이 이해할 수 있는 난이도로 작성한다.
 - 질문의 구체성, 맥락성, 목적성과 연결된 학습 포인트를 반영한다.
-- 단순히 라벨만 맞추지 말고, 문항이 요구하는 행동과 `quiz_type`이 실제로 일치해야 한다.
-- `learning_dimension`은 해설과 학습 포인트가 실제로 설명하는 질문력 요소와 일치해야 한다.
+- quiz 성격의 서비스라면 단순히 라벨만 맞추지 말고, 문항이 요구하는 행동과 `quiz_type`이 실제로 일치해야 한다.

--- a/prompts/implementation/prototype_builder.md
+++ b/prompts/implementation/prototype_builder.md
@@ -22,6 +22,21 @@
 콘텐츠 데이터:
 {content_interaction_output}
 
+interaction_mode:
+{interaction_mode}
+
+interaction_mode_reason:
+{interaction_mode_reason}
+
+interaction_units(primary contract):
+{interaction_units}
+
+flow_notes:
+{flow_notes}
+
+evaluation_rules:
+{evaluation_rules}
+
 interface_spec:
 {interface_spec}
 
@@ -45,6 +60,9 @@ prompt_spec:
   - 콘텐츠 파일이 없으면 `st.warning(...)` 또는 `st.error(...)`로 사용자에게 안내해야 한다.
 - 금지: `CONTENT_PATH = "{content_filename}"`를 먼저 검사한 뒤 `outputs/{content_filename}`를 fallback으로 읽는 root-first 로딩 구조.
 - app.py 실행 시 planning package 파일(interface_spec.md, state_machine.md, data_schema.json, prompt_spec.md, constitution.md)을 다시 읽으면 안 된다.
+- `interaction_units`는 화면 흐름 생성을 위한 primary contract다.
+- 화면 흐름은 `interaction_units`의 순서, `interaction_type`, `next_step`, `metadata`를 기준으로 구성한다.
+- `interaction_mode`는 secondary hint only다. quiz/coaching 전용 deterministic template을 새로 만들지 말고, `interaction_units` 계약을 우선 해석하라.
 - 세션 런타임 quest는 `quest_id`, `quest_type`, `difficulty`, `topic_context`, `original_question`, `options` 필드를 기준으로 동작해야 한다.
 - raw 콘텐츠 필드 `item_id`, `choices`는 정규화 단계에서만 사용하고, 제출/결과 화면 로직에서 직접 참조하지 않는다.
 - `streamlit` 앱에서 사용자는 문제 풀이, 정답 확인, 해설과 학습 포인트 확인이 가능해야 한다.

--- a/schemas/implementation/__init__.py
+++ b/schemas/implementation/__init__.py
@@ -2,6 +2,7 @@ from schemas.implementation.common import (
     AgentLabel,
     FailureRecord,
     GeneratedFile,
+    InteractionUnit,
     LocalCheckResult,
     PatchedFile,
     QuizGenerationRequirements,
@@ -11,6 +12,9 @@ from schemas.implementation.common import (
 from schemas.implementation.content_interaction import (
     ContentInteractionInput,
     ContentInteractionOutput,
+    InteractionValidationSummary,
+    SemanticValidationItemResult,
+    SemanticValidationSummary,
 )
 from schemas.implementation.implementation_spec import (
     ImplementationSpec,
@@ -43,6 +47,8 @@ __all__ = [
     "FailureRecord",
     "GeneratedFile",
     "ImplementationSpec",
+    "InteractionUnit",
+    "InteractionValidationSummary",
     "LocalCheckResult",
     "PatchedFile",
     "PrototypeBuilderInput",
@@ -56,6 +62,8 @@ __all__ = [
     "RunTestAndFixInput",
     "RunTestAndFixOutput",
     "SchemaModel",
+    "SemanticValidationItemResult",
+    "SemanticValidationSummary",
     "SpecIntakeInput",
     "SpecIntakeOutput",
     "parse_markdown_spec",

--- a/schemas/implementation/common.py
+++ b/schemas/implementation/common.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from pydantic import BaseModel, ConfigDict, Field
 
 
@@ -46,6 +48,42 @@ class QuizItem(SchemaModel):
     correct_choice: str = Field(description="Correct answer string from the choices.")
     explanation: str = Field(description="Why the correct choice is correct.")
     learning_point: str = Field(description="Educational takeaway from the item.")
+
+
+class InteractionUnit(SchemaModel):
+    unit_id: str = Field(description="Unique interaction-unit identifier.")
+    interaction_type: str = Field(
+        description="Interaction type such as multiple_choice, free_text_input, feedback, or coaching_feedback."
+    )
+    title: str = Field(default="", description="Optional short title for the unit.")
+    learner_action: str = Field(
+        default="",
+        description="What the learner is expected to do at this step.",
+    )
+    system_response: str = Field(
+        default="",
+        description="What the system shows or says during this step.",
+    )
+    input_format: str = Field(
+        default="",
+        description="Optional input format hint, for example multiple choice or free text.",
+    )
+    feedback_rule: str = Field(
+        default="",
+        description="Rule or policy describing how feedback is produced at this step.",
+    )
+    learning_dimension: str = Field(
+        default="",
+        description="Learning dimension associated with this interaction step, if any.",
+    )
+    next_step: str = Field(
+        default="",
+        description="Next unit id or END when the interaction flow finishes.",
+    )
+    metadata: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Additional structured metadata used by downstream builders.",
+    )
 
 
 class GeneratedFile(SchemaModel):

--- a/schemas/implementation/content_interaction.py
+++ b/schemas/implementation/content_interaction.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from typing import Any
+
 from pydantic import Field
 
-from schemas.implementation.common import AgentLabel, QuizItem, SchemaModel
+from schemas.implementation.common import AgentLabel, InteractionUnit, QuizItem, SchemaModel
 from schemas.implementation.implementation_spec import ImplementationSpec
 from schemas.implementation.requirement_mapping import RequirementMappingOutput
 from schemas.implementation.spec_intake import SpecIntakeOutput
@@ -82,10 +84,38 @@ class SemanticValidationSummary(SchemaModel):
     )
 
 
+class InteractionValidationSummary(SchemaModel):
+    interaction_mode: str = Field(description="Interaction strategy hint used by the agent.")
+    mode_inference_reason: str = Field(
+        default="",
+        description="Deterministic explanation for how interaction_mode was inferred.",
+    )
+    unit_count: int = Field(description="Total number of interaction units.")
+    unit_type_counts: dict[str, int] = Field(
+        default_factory=dict,
+        description="Counts by interaction_type.",
+    )
+    structure_valid: bool = Field(
+        description="Whether interaction_units satisfied the structural validator.",
+    )
+    issues: list[str] = Field(
+        default_factory=list,
+        description="Validation issues found in the interaction-unit structure.",
+    )
+
+
 class ContentInteractionOutput(SchemaModel):
     agent: AgentLabel | None = Field(default=None, description="Agent label metadata.")
     service_summary: str = Field(
-        description="Short summary describing the generated quiz service."
+        description="Short summary describing the generated educational service."
+    )
+    interaction_mode: str = Field(
+        default="quiz",
+        description="Generation and validation hint: quiz, coaching, or general.",
+    )
+    interaction_mode_reason: str = Field(
+        default="",
+        description="Reason why the interaction_mode was chosen.",
     )
     quiz_types: list[str] = Field(
         default_factory=list,
@@ -111,7 +141,23 @@ class ContentInteractionOutput(SchemaModel):
         default_factory=list,
         description="Notes describing how the learner should experience the quiz flow.",
     )
+    interaction_units: list[InteractionUnit] = Field(
+        default_factory=list,
+        description="Primary structured interaction flow units for downstream builders.",
+    )
+    flow_notes: list[str] = Field(
+        default_factory=list,
+        description="High-level flow notes describing how the interaction should progress.",
+    )
+    evaluation_rules: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Generalized evaluation rules for quiz scoring or coaching feedback.",
+    )
     semantic_validation: SemanticValidationSummary | None = Field(
         default=None,
         description="Semantic validation summary for the generated content.",
+    )
+    interaction_validation: InteractionValidationSummary | None = Field(
+        default=None,
+        description="Structural validation summary for interaction_units.",
     )

--- a/schemas/implementation/qa_alignment.py
+++ b/schemas/implementation/qa_alignment.py
@@ -19,7 +19,7 @@ class QAAlignmentInput(SchemaModel):
         description="Implementation contract output."
     )
     content_interaction_output: ContentInteractionOutput = Field(
-        description="Generated quiz contents and interaction notes."
+        description="Generated educational contents and interaction structures."
     )
     prototype_builder_output: PrototypeBuilderOutput = Field(
         description="Generated code artifacts."

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -131,6 +131,12 @@ class FakeLLMClient:
             total_count = _extract_int_from_prompt(prompt, "total_count", default=8)
             items_per_type = _extract_int_from_prompt(prompt, "items_per_type", default=2)
             service_name = _extract_scalar_from_prompt(prompt, "service_name") or "교육 서비스"
+            interaction_mode = _extract_scalar_from_prompt(prompt, "interaction_mode(hint only)") or _extract_scalar_from_prompt(prompt, "interaction_mode") or _infer_fake_interaction_mode(content_types, prompt)
+            interaction_mode_reason = (
+                "fake deterministic mode inference"
+                if interaction_mode != "general"
+                else "fake deterministic fallback to general mode"
+            )
 
             if (
                 content_types == DEFAULT_CONTENT_TYPES
@@ -138,6 +144,35 @@ class FakeLLMClient:
                 and total_count == 8
             ):
                 return self._build_default_content_output(response_model)
+
+            if interaction_mode in {"coaching", "general"} and not _looks_like_quiz_content_types(content_types):
+                interaction_units = _build_non_quiz_interaction_units(
+                    service_name=service_name,
+                    learning_dimensions=learning_dimensions,
+                )
+                return response_model.model_validate(
+                    {
+                        "agent": {
+                            "english_name": "Content & Interaction Agent",
+                            "korean_name": "교육 콘텐츠·상호작용 생성 Agent",
+                        },
+                        "service_summary": f"{service_name}용 interaction-unit 중심 콘텐츠다.",
+                        "interaction_mode": interaction_mode,
+                        "interaction_mode_reason": interaction_mode_reason,
+                        "interaction_units": interaction_units,
+                        "flow_notes": [
+                            "사용자는 자유 입력을 하고 진단 결과를 본 뒤 다음 행동을 안내받는다.",
+                        ],
+                        "evaluation_rules": {
+                            "mode": interaction_mode,
+                            "diagnosis_criteria": learning_dimensions,
+                            "feedback_policy": "사용자 자유 입력을 기반으로 개선 방향을 제안한다.",
+                        },
+                        "interaction_notes": [
+                            "interaction_units를 primary contract로 사용한다.",
+                        ],
+                    }
+                )
 
             items = []
             answer_key = {}
@@ -181,6 +216,8 @@ class FakeLLMClient:
                 explanations[item_id] = explanation
                 learning_points[item_id] = learning_point
 
+            interaction_units = _build_quiz_interaction_units_from_items(items)
+
             return response_model.model_validate(
                 {
                     "agent": {
@@ -188,6 +225,8 @@ class FakeLLMClient:
                         "korean_name": "교육 콘텐츠·상호작용 생성 Agent",
                     },
                     "service_summary": f"{service_name}용 {total_count}문항 콘텐츠다.",
+                    "interaction_mode": interaction_mode,
+                    "interaction_mode_reason": interaction_mode_reason,
                     "quiz_types": content_types,
                     "items": items,
                     "answer_key": answer_key,
@@ -197,6 +236,15 @@ class FakeLLMClient:
                         "사용자는 문제를 순서대로 풀 수 있다.",
                         "채점 후 각 문항의 정답, 해설, 학습 포인트를 확인한다.",
                     ],
+                    "interaction_units": interaction_units,
+                    "flow_notes": [
+                        "interaction_units의 순서와 next_step에 따라 화면 흐름을 구성한다.",
+                    ],
+                    "evaluation_rules": {
+                        "mode": "quiz",
+                        "score_policy": {"per_item": 1, "total_items": total_count},
+                        "feedback_type": "feedback",
+                    },
                 }
             )
 
@@ -499,6 +547,8 @@ class FakeLLMClient:
             explanations[item_id] = explanation
             learning_points[item_id] = learning_point
 
+        interaction_units = _build_quiz_interaction_units_from_items(items)
+
         return response_model.model_validate(
             {
                 "agent": {
@@ -506,6 +556,8 @@ class FakeLLMClient:
                     "korean_name": "교육 콘텐츠·상호작용 생성 Agent",
                 },
                 "service_summary": "중학생의 질문력을 높이는 8문항 퀴즈형 MVP 콘텐츠다.",
+                "interaction_mode": "quiz",
+                "interaction_mode_reason": "fake deterministic mode inference",
                 "quiz_types": quiz_types,
                 "items": items,
                 "answer_key": answer_key,
@@ -515,6 +567,15 @@ class FakeLLMClient:
                     "사용자는 객관식 문제를 순서대로 풀 수 있다.",
                     "채점 후 각 문항의 정답, 해설, 학습 포인트를 확인한다.",
                 ],
+                "interaction_units": interaction_units,
+                "flow_notes": [
+                    "interaction_units의 순서와 next_step에 따라 문제 풀이와 결과 화면이 이어진다.",
+                ],
+                "evaluation_rules": {
+                    "mode": "quiz",
+                    "score_policy": {"per_item": 1, "total_items": 8},
+                    "feedback_type": "feedback",
+                },
             }
         )
 
@@ -531,6 +592,156 @@ def _build_question_for_type(quiz_type: str) -> str:
     if quiz_type == "상황에 맞는 질문 만들기":
         return "다음 상황에서 가장 적절한 질문은 무엇일까? (과학 발표 준비)"
     return "다음 중 더 좋은 질문은 무엇일까?"
+
+
+def _infer_fake_interaction_mode(content_types: list[str], prompt: str) -> str:
+    lowered = prompt.lower()
+    if any(marker in lowered for marker in ["/api/chat", "coaching", "되묻기", "챗봇"]):
+        return "coaching"
+    if _looks_like_quiz_content_types(content_types):
+        return "quiz"
+    return "general"
+
+
+def _looks_like_quiz_content_types(content_types: list[str]) -> bool:
+    quiz_markers = {
+        "multiple_choice",
+        "question_improvement",
+        "질문에서 빠진 요소 찾기",
+        "더 좋은 질문 고르기",
+        "모호한 질문 고치기",
+        "상황에 맞는 질문 만들기",
+    }
+    return bool(content_types) and all(content_type in quiz_markers for content_type in content_types)
+
+
+def _build_quiz_interaction_units_from_items(items: list[dict[str, object]]) -> list[dict[str, object]]:
+    units: list[dict[str, object]] = []
+    for item in items:
+        item_id = str(item["item_id"])
+        quiz_type = str(item["quiz_type"])
+        action_type = "free_text_input" if quiz_type == "question_improvement" else "multiple_choice"
+        units.append(
+            {
+                "unit_id": f"{item_id}_action",
+                "interaction_type": action_type,
+                "title": item["title"],
+                "learner_action": item["question"],
+                "system_response": item["topic_context"],
+                "input_format": "free_text" if action_type == "free_text_input" else "multiple_choice",
+                "feedback_rule": "응답 후 결과 피드백을 제공한다.",
+                "learning_dimension": item["learning_dimension"],
+                "next_step": f"{item_id}_feedback",
+                "metadata": {
+                    "source_item_id": item_id,
+                    "quiz_type": quiz_type,
+                    "choices": list(item["choices"]),
+                    "correct_choice": item["correct_choice"],
+                    "difficulty": item["difficulty"],
+                    "topic_context": item["topic_context"],
+                    "original_question": item["original_question"],
+                },
+            }
+        )
+        units.append(
+            {
+                "unit_id": f"{item_id}_feedback",
+                "interaction_type": "feedback",
+                "title": f"{item['title']} 결과",
+                "learner_action": "",
+                "system_response": item["explanation"],
+                "input_format": "",
+                "feedback_rule": "정답, 해설, 학습 포인트를 보여 준다.",
+                "learning_dimension": item["learning_dimension"],
+                "next_step": "",
+                "metadata": {
+                    "source_item_id": item_id,
+                    "choices": list(item["choices"]),
+                    "correct_choice": item["correct_choice"],
+                    "explanation": item["explanation"],
+                    "learning_point": item["learning_point"],
+                },
+            }
+        )
+
+    units.append(
+        {
+            "unit_id": "session_summary",
+            "interaction_type": "score_summary",
+            "title": "세션 요약",
+            "learner_action": "",
+            "system_response": "전체 점수와 학습 포인트를 요약한다.",
+            "input_format": "",
+            "feedback_rule": "세션 종료 시 전체 결과를 요약한다.",
+            "learning_dimension": "",
+            "next_step": "END",
+            "metadata": {"source": "fake_quiz_session"},
+        }
+    )
+
+    for index, unit in enumerate(units):
+        if unit["next_step"]:
+            continue
+        unit["next_step"] = units[index + 1]["unit_id"] if index + 1 < len(units) else "END"
+    return units
+
+
+def _build_non_quiz_interaction_units(
+    *,
+    service_name: str,
+    learning_dimensions: list[str],
+) -> list[dict[str, object]]:
+    primary_dimension = learning_dimensions[0] if learning_dimensions else "구체성"
+    return [
+        {
+            "unit_id": "chat_input",
+            "interaction_type": "free_text_input",
+            "title": f"{service_name} 질문 입력",
+            "learner_action": "학습자가 현재 질문이나 고민을 자유롭게 입력한다.",
+            "system_response": "질문을 입력하면 진단을 시작한다.",
+            "input_format": "free_text",
+            "feedback_rule": "입력 후 diagnosis 단계로 이동한다.",
+            "learning_dimension": primary_dimension,
+            "next_step": "chat_diagnosis",
+            "metadata": {"purpose": "user_question_input"},
+        },
+        {
+            "unit_id": "chat_diagnosis",
+            "interaction_type": "diagnosis",
+            "title": "질문 진단",
+            "learner_action": "",
+            "system_response": "질문의 구체성, 맥락성, 목적성을 간단히 진단한다.",
+            "input_format": "",
+            "feedback_rule": "진단 기준을 바탕으로 coaching_feedback으로 이동한다.",
+            "learning_dimension": primary_dimension,
+            "next_step": "chat_feedback",
+            "metadata": {"diagnosis_criteria": learning_dimensions},
+        },
+        {
+            "unit_id": "chat_feedback",
+            "interaction_type": "coaching_feedback",
+            "title": "개선 피드백",
+            "learner_action": "",
+            "system_response": "사용자 자유 입력을 바탕으로 더 좋은 질문 방향을 제안한다.",
+            "input_format": "",
+            "feedback_rule": "coaching feedback을 제공한 뒤 다음 행동을 안내한다.",
+            "learning_dimension": primary_dimension,
+            "next_step": "next_step_guide",
+            "metadata": {"feedback_scope": "question_improvement"},
+        },
+        {
+            "unit_id": "next_step_guide",
+            "interaction_type": "next_step_guide",
+            "title": "다음 단계 안내",
+            "learner_action": "",
+            "system_response": "개선된 질문을 다시 입력하거나 세션을 종료할 수 있다.",
+            "input_format": "",
+            "feedback_rule": "세션 종료 또는 재입력을 안내한다.",
+            "learning_dimension": primary_dimension,
+            "next_step": "END",
+            "metadata": {"completion": "guided"},
+        },
+    ]
 
 
 def _build_choices_for_type(quiz_type: str) -> list[str]:

--- a/tests/test_content_interaction_semantics.py
+++ b/tests/test_content_interaction_semantics.py
@@ -6,12 +6,12 @@ from pathlib import Path
 import pytest
 
 from agents.implementation.content_interaction_agent import run_content_interaction_agent
-from schemas.implementation.common import QuizItem
+from schemas.implementation.common import InteractionUnit, QuizItem
 from schemas.implementation.content_interaction import (
     ContentInteractionInput,
     ContentInteractionOutput,
 )
-from schemas.implementation.implementation_spec import parse_markdown_spec
+from schemas.implementation.implementation_spec import ImplementationSpec, parse_markdown_spec
 from schemas.implementation.requirement_mapping import RequirementMappingOutput
 from schemas.implementation.spec_intake import SpecIntakeOutput
 from tests.fakes import FakeLLMClient
@@ -53,9 +53,15 @@ def _build_input_models() -> tuple[SpecIntakeOutput, RequirementMappingOutput]:
     )
 
 
-def _build_input(content_output: ContentInteractionOutput, client) -> ContentInteractionOutput:
+def _build_input(
+    content_output: ContentInteractionOutput,
+    client,
+    implementation_spec: ImplementationSpec | None = None,
+) -> ContentInteractionOutput:
     spec_intake_output, requirement_mapping_output = _build_input_models()
-    implementation_spec = parse_markdown_spec(REPO_ROOT / "inputs" / "quiz_service_spec.md")
+    implementation_spec = implementation_spec or parse_markdown_spec(
+        REPO_ROOT / "inputs" / "quiz_service_spec.md"
+    )
     return run_content_interaction_agent(
         ContentInteractionInput(
             spec_intake_output=spec_intake_output,
@@ -64,6 +70,15 @@ def _build_input(content_output: ContentInteractionOutput, client) -> ContentInt
         ),
         client,
     )
+
+
+def test_interaction_unit_metadata_uses_independent_default_dict() -> None:
+    first = InteractionUnit(unit_id="u1", interaction_type="feedback")
+    second = InteractionUnit(unit_id="u2", interaction_type="feedback")
+
+    first.metadata["key"] = "value"
+
+    assert second.metadata == {}
 
 
 def test_label_correction_only_does_not_trigger_regeneration() -> None:
@@ -79,6 +94,10 @@ def test_label_correction_only_does_not_trigger_regeneration() -> None:
     assert result.items[0].learning_dimension == "맥락성"
     assert result.semantic_validation is not None
     assert result.semantic_validation.regeneration_count == 0
+    assert result.interaction_mode == "quiz"
+    assert result.interaction_validation is not None
+    assert result.interaction_validation.structure_valid is True
+    assert any(unit.interaction_type == "feedback" for unit in result.interaction_units)
     assert client.calls == ["ContentInteractionOutput"]
 
 
@@ -120,6 +139,8 @@ def test_semantic_mismatch_triggers_single_item_regeneration() -> None:
     assert result.semantic_validation is not None
     assert result.semantic_validation.regeneration_count == 1
     assert broken_item.item_id in result.semantic_validation.regenerated_item_ids
+    assert result.interaction_validation is not None
+    assert result.interaction_validation.structure_valid is True
     assert client.calls == ["ContentInteractionOutput", "QuizItem"]
 
 
@@ -155,3 +176,203 @@ def test_regeneration_failure_raises_value_error() -> None:
 
     with pytest.raises(ValueError):
         _build_input(content_output, client)
+
+
+def test_coaching_mode_uses_interaction_units_as_primary_contract() -> None:
+    spec_intake_output = SpecIntakeOutput.model_validate(
+        {
+            "team_identity": "교육 서비스 구현 전문 AI Agent 팀",
+            "service_summary": "질문 입력을 받아 되묻기와 진단으로 개선 방향을 제안하는 코칭형 서비스다.",
+            "normalized_requirements": ["사용자 질문 입력", "진단", "코칭 피드백"],
+            "delivery_expectations": ["interaction_units 생성"],
+            "acceptance_focus": ["interaction_units 구조 validator 통과"],
+        }
+    )
+    requirement_mapping_output = RequirementMappingOutput.model_validate(
+        {
+            "implementation_targets": ["coaching interaction flow"],
+            "file_plan": [],
+            "quiz_generation_requirements": {
+                "quiz_type_count": 0,
+                "items_per_type": 0,
+                "total_items": 0,
+                "required_fields": [],
+            },
+            "app_constraints": ["chat-like follow-up flow"],
+            "test_strategy": ["interaction validator"],
+        }
+    )
+    implementation_spec = ImplementationSpec(
+        source_path=str(REPO_ROOT / "inputs" / "260428_챗봇"),
+        service_name="질문 개선 코칭 챗봇",
+        target_framework="streamlit",
+        team_identity="교육 서비스 구현 전문 AI Agent 팀",
+        service_purpose="질문 입력을 받아 진단과 되묻기로 개선 방향을 제안하는 챗봇 코칭 서비스",
+        target_users=["중학생"],
+        learning_goals=["구체성", "맥락성", "목적성"],
+        core_features=["follow_up", "diagnosis", "coaching_feedback"],
+        total_count=0,
+        items_per_type=0,
+        content_interaction_direction=["/api/chat", "질문 입력", "되묻기", "진단"],
+        excluded_scope=[],
+        expected_outputs=["chat demo"],
+        acceptance_criteria=["interaction_units가 유효해야 한다."],
+        constraints=[],
+    )
+    content_output = ContentInteractionOutput.model_validate(
+        {
+            "service_summary": "질문 개선 코칭 챗봇용 상호작용 구조다.",
+            "interaction_units": [
+                {
+                    "unit_id": "chat_input",
+                    "interaction_type": "free_text_input",
+                    "title": "질문 입력",
+                    "learner_action": "현재 질문을 입력한다.",
+                    "system_response": "질문을 받으면 진단을 시작한다.",
+                    "input_format": "free_text",
+                    "next_step": "chat_diagnosis",
+                    "metadata": {"purpose": "user_input"},
+                },
+                {
+                    "unit_id": "chat_diagnosis",
+                    "interaction_type": "diagnosis",
+                    "title": "질문 진단",
+                    "system_response": "질문의 구체성, 맥락성, 목적성을 진단한다.",
+                    "next_step": "chat_feedback",
+                    "metadata": {"diagnosis_criteria": ["구체성", "맥락성", "목적성"]},
+                },
+                {
+                    "unit_id": "chat_feedback",
+                    "interaction_type": "coaching_feedback",
+                    "title": "개선 피드백",
+                    "system_response": "더 구체적인 질문으로 바꾸는 방향을 제안한다.",
+                    "next_step": "next_step_guide",
+                    "metadata": {"feedback_scope": "question_improvement"},
+                },
+                {
+                    "unit_id": "next_step_guide",
+                    "interaction_type": "next_step_guide",
+                    "title": "다음 단계",
+                    "system_response": "다시 질문을 입력하거나 종료할 수 있다.",
+                    "next_step": "END",
+                    "metadata": {"completion": "guided"},
+                },
+            ],
+            "flow_notes": ["자유 입력 -> 진단 -> 코칭 피드백 -> 다음 단계 안내"],
+            "evaluation_rules": {
+                "diagnosis_criteria": ["구체성", "맥락성", "목적성"],
+                "feedback_policy": "사용자 자유 입력을 기준으로 개선 방향을 제안한다.",
+            },
+        }
+    )
+
+    client = ScriptedContentClient(initial_content_output=content_output)
+    result = run_content_interaction_agent(
+        ContentInteractionInput(
+            spec_intake_output=spec_intake_output,
+            requirement_mapping_output=requirement_mapping_output,
+            implementation_spec=implementation_spec,
+        ),
+        client,
+    )
+
+    assert result.interaction_mode == "coaching"
+    assert "coaching markers detected" in result.interaction_mode_reason
+    assert result.semantic_validation is None
+    assert result.interaction_validation is not None
+    assert result.interaction_validation.structure_valid is True
+    assert result.items == []
+    assert any(unit.interaction_type == "coaching_feedback" for unit in result.interaction_units)
+    assert "diagnosis_criteria" in result.evaluation_rules
+
+
+def test_conflicting_mode_markers_fall_back_to_general_when_units_are_valid() -> None:
+    spec_intake_output = SpecIntakeOutput.model_validate(
+        {
+            "team_identity": "교육 서비스 구현 전문 AI Agent 팀",
+            "service_summary": "퀴즈와 챗봇형 되묻기가 섞인 혼합 서비스다.",
+            "normalized_requirements": ["객관식 문항", "질문 입력", "되묻기"],
+            "delivery_expectations": ["interaction_units 생성"],
+            "acceptance_focus": ["general mode에서도 interaction_units 구조가 유효해야 한다."],
+        }
+    )
+    requirement_mapping_output = RequirementMappingOutput.model_validate(
+        {
+            "implementation_targets": ["hybrid interaction flow"],
+            "file_plan": [],
+            "quiz_generation_requirements": {
+                "quiz_type_count": 0,
+                "items_per_type": 0,
+                "total_items": 0,
+                "required_fields": [],
+            },
+            "app_constraints": ["multiple interaction styles"],
+            "test_strategy": ["interaction validator"],
+        }
+    )
+    implementation_spec = ImplementationSpec(
+        source_path=str(REPO_ROOT / "inputs" / "260429_퀘스트_v2"),
+        service_name="혼합형 질문 학습 서비스",
+        target_framework="streamlit",
+        team_identity="교육 서비스 구현 전문 AI Agent 팀",
+        service_purpose="퀴즈와 챗봇형 되묻기가 함께 있는 학습 서비스",
+        target_users=["중학생"],
+        learning_goals=["구체성", "맥락성", "목적성"],
+        core_features=["multiple_choice", "diagnosis", "coaching"],
+        total_count=0,
+        items_per_type=0,
+        content_interaction_direction=["문항", "/api/chat", "되묻기"],
+        excluded_scope=[],
+        expected_outputs=["hybrid demo"],
+        acceptance_criteria=["interaction_units가 유효해야 한다."],
+        constraints=[],
+    )
+    content_output = ContentInteractionOutput.model_validate(
+        {
+            "service_summary": "혼합형 상호작용 구조다.",
+            "interaction_units": [
+                {
+                    "unit_id": "intro",
+                    "interaction_type": "display_content",
+                    "title": "시작",
+                    "system_response": "오늘의 학습 흐름을 안내한다.",
+                    "next_step": "ask",
+                    "metadata": {"role": "intro"},
+                },
+                {
+                    "unit_id": "ask",
+                    "interaction_type": "free_text_input",
+                    "title": "질문 입력",
+                    "learner_action": "질문을 입력한다.",
+                    "input_format": "free_text",
+                    "next_step": "feedback",
+                    "metadata": {"purpose": "question_input"},
+                },
+                {
+                    "unit_id": "feedback",
+                    "interaction_type": "feedback",
+                    "title": "결과",
+                    "system_response": "입력 결과를 요약한다.",
+                    "next_step": "END",
+                    "metadata": {"result_type": "summary"},
+                },
+            ],
+            "flow_notes": ["안내 -> 입력 -> 결과"],
+        }
+    )
+
+    client = ScriptedContentClient(initial_content_output=content_output)
+    result = run_content_interaction_agent(
+        ContentInteractionInput(
+            spec_intake_output=spec_intake_output,
+            requirement_mapping_output=requirement_mapping_output,
+            implementation_spec=implementation_spec,
+        ),
+        client,
+    )
+
+    assert result.interaction_mode == "general"
+    assert "conflicting quiz/coaching markers detected" in result.interaction_mode_reason
+    assert result.interaction_validation is not None
+    assert result.interaction_validation.structure_valid is True
+    assert result.semantic_validation is None

--- a/tests/test_orchestrator.py
+++ b/tests/test_orchestrator.py
@@ -73,6 +73,9 @@ def test_pipeline_with_fake_llm_generates_expected_outputs(tmp_path: Path) -> No
         "상황에 맞는 질문 만들기",
     }
     assert all("learning_dimension" in item for item in quiz_contents["items"])
+    assert quiz_contents["interaction_mode"] == "quiz"
+    assert len(quiz_contents["interaction_units"]) >= len(quiz_contents["items"]) * 2
+    assert quiz_contents["interaction_validation"]["structure_valid"] is True
     assert quiz_contents["semantic_validation"]["semantic_validator_passed"] is True
     assert quiz_contents["semantic_validation"]["quiz_type_distribution_valid"] is True
     assert quiz_contents["semantic_validation"]["learning_dimension_values_valid"] is True
@@ -107,10 +110,14 @@ def test_pipeline_with_planning_package_generates_service_named_contents(tmp_pat
     assert intake_report_path.exists()
     assert "Input Intake" in final_summary
     assert "Input Intake" in qa_report
+    assert "interaction_mode" in final_summary
+    assert "interaction_units 수" in qa_report
     assert content_path.exists()
     payload = json.loads(content_path.read_text(encoding="utf-8"))
     assert len(payload["items"]) == 3
     assert set(payload["quiz_types"]) == {"multiple_choice", "question_improvement"}
+    assert payload["interaction_mode"] == "quiz"
+    assert payload["interaction_validation"]["structure_valid"] is True
     assert [item["quiz_type"] for item in payload["items"]] == [
         "multiple_choice",
         "question_improvement",

--- a/tests/test_prototype_builder_agent.py
+++ b/tests/test_prototype_builder_agent.py
@@ -92,6 +92,9 @@ def test_prototype_builder_materializes_llm_generated_app_from_planning_package(
     assert "quest_id" in prompt
     assert "current_screen" in prompt
     assert "st.rerun()" in prompt
+    assert "interaction_units(primary contract)" in prompt
+    assert '"interaction_mode": "quiz"' in prompt or "interaction_mode:\nquiz" in prompt
+    assert "primary contract" in prompt
 
 
 def test_prototype_builder_uses_fallback_when_llm_call_fails() -> None:


### PR DESCRIPTION
## Summary
- Content & Interaction Agent 출력 구조를 `QuizItem` 중심에서 `InteractionUnit` 중심으로 일반화했습니다.
- 기존 질문력 퀘스트 경로는 깨지지 않도록 `items`, `quiz_types`, `answer_key` 등 legacy 필드를 그대로 유지했습니다.
- Prototype Builder는 `interaction_units`를 app.py 생성의 primary contract로 읽고, `interaction_mode`는 generation/validation hint로만 다루도록 정리했습니다.

## What Changed
### 1. InteractionUnit 추가
- `schemas/implementation/common.py`에 `InteractionUnit`를 추가했습니다.
- 필드:
  - `unit_id`
  - `interaction_type`
  - `title`
  - `learner_action`
  - `system_response`
  - `input_format`
  - `feedback_rule`
  - `learning_dimension`
  - `next_step`
  - `metadata`
- `metadata`는 `Field(default_factory=dict)`로 구현했습니다.

### 2. ContentInteractionOutput 일반화
- `schemas/implementation/content_interaction.py`에 아래 필드를 추가했습니다.
  - `interaction_mode`
  - `interaction_mode_reason`
  - `interaction_units`
  - `flow_notes`
  - `evaluation_rules`
  - `interaction_validation`
- 기존 `semantic_validation`은 quiz mode에서만 의미 있게 유지하고, non-quiz mode에서는 `N/A` 성격으로 처리합니다.

### 3. QuizItem 하위 호환 방식
- quiz mode에서는 기존 `QuizItem` 생성, semantic validator, regeneration 경로를 그대로 유지합니다.
- 동시에 `items`에서 deterministic하게 `interaction_units`를 합성합니다.
- 각 `QuizItem`은 최소 다음 unit으로 변환됩니다.
  - action unit: `multiple_choice` 또는 `free_text_input`
  - result unit: `feedback`
- 마지막에는 `score_summary` unit을 추가합니다.

### 4. mode 추론 방식과 한계
- `interaction_mode`는 `quiz`, `coaching`, `general` 중 하나로 deterministic 추론합니다.
- quiz 신호가 우세하면 `quiz`, coaching 신호가 우세하면 `coaching`, 신호가 충돌하거나 약하면 `general`로 둡니다.
- `general`은 실패 상태가 아니라 안전한 중립 모드입니다. `interaction_units`가 유효하면 그대로 진행합니다.
- 추론 이유는 `interaction_mode_reason`에 기록하고 QA/final summary에도 남깁니다.
- 한계:
  - 키워드와 spec 요약 기반의 보수적 추론이므로, 복합 서비스는 의도적으로 `general`로 떨어질 수 있습니다.

### 5. feedback vs coaching_feedback 구분
- `feedback`: 정답/해설/결과에 대한 일반 피드백
- `coaching_feedback`: 사용자 자유 입력을 바탕으로 개선 방향을 제안하는 코칭형 피드백
- quiz 해설 결과는 `feedback`, 자유 입력 개선 제안은 `coaching_feedback`으로 분리했습니다.

### 6. Prototype Builder 연동 방식
- `prompts/implementation/prototype_builder.md`와 `agents/implementation/prototype_builder_agent.py`를 수정해 아래를 app generation prompt에 명시적으로 넣었습니다.
  - `interaction_mode`
  - `interaction_mode_reason`
  - `interaction_units`
  - `flow_notes`
  - `evaluation_rules`
- 프롬프트에는 `interaction_units`가 화면 흐름 생성을 위한 primary contract라고 명시했습니다.
- 화면 흐름은 `interaction_units`의 순서, `interaction_type`, `next_step`, `metadata`를 기준으로 구성하도록 요구합니다.
- `interaction_mode`는 secondary hint only로 두고, quiz/coaching 전용 deterministic app template은 추가하지 않았습니다.

### 7. QA / Final Summary 반영
- QA checklist와 final summary에 아래를 항상 남기도록 했습니다.
  - `interaction_mode`
  - `interaction_mode_reason`
  - `interaction_units` 수
  - `interaction_type` 분포
  - `QuizItem` 수
  - quiz backward compatibility 사용 여부
- non-quiz mode에서는 quiz semantic check를 `N/A`로 표시하고 실패로 보지 않습니다.

### 8. 문서 추가
- `docs/content_interaction_generalization.md`
- 포함 내용:
  - 기존 `QuizItem` 중심 구조의 한계
  - `InteractionUnit` 도입 이유
  - 하위 호환 방식
  - mode 추론 방식과 한계
  - `feedback` / `coaching_feedback` 구분
  - Builder primary contract 연결 방식
  - #31 후속 검증 범위

## Tests
- `./.venv/bin/python -m pytest -q` → `55 passed`
- `./.venv/bin/python main.py --input-package inputs/mock_planning_outputs/question_quest_v0/ --skip-streamlit-smoke` → 성공
- 추가 검증 포인트:
  - quiz mode에서 `interaction_units` 자동 합성
  - coaching/general mode에서 interaction validator 적용
  - Builder prompt에 `interaction_units(primary contract)` 포함
  - package pipeline 결과에 `interaction_mode`, `interaction_units`, `interaction_validation` 저장

## Remaining Limits
- 이번 이슈는 구조 일반화와 Builder prompt 연동까지가 범위입니다.
- `inputs/260428_챗봇/`, `inputs/260429_퀘스트_v2/` 기준의 정식 결과 비교와 의미 정합성 평가는 아직 하지 않았습니다.
- live package 실행에서 Prototype Builder는 여전히 fallback template로 끝날 수 있습니다. 이건 기존 app generation 품질 이슈이며, #37의 목표는 아닙니다.

## Follow-up for #31
- `inputs/260428_챗봇/` 기준 interaction_units 결과 비교
- `inputs/260429_퀘스트_v2/` 기준 interaction_units 결과 비교
- multi-service live output 의미 정합성 검증
- non-quiz interaction_units를 Builder가 실제 화면 흐름으로 얼마나 자연스럽게 옮기는지 검증
