### PR TITLE
LLM provider 우선순위를 Gemini -> Upstage로 정리

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,11 +63,30 @@ cp .env.example .env
 
 ## 환경변수
 
-runtime 실행은 OpenAI-compatible LLM client를 사용한다.
+runtime 실행은 provider-priority LLM client를 사용한다.
+
+우선순위는 아래와 같다.
+
+1. Gemini API (`GEMINI_API_KEY`)
+2. Upstage API (`UPSTAGE_API_KEY`)
+
+앞선 provider가 실패하면 다음 provider로 자동 failover 한다.
+
+### Gemini 예시
+
+```bash
+export GEMINI_API_KEY="..."
+export GEMINI_MODEL="gemini-3.1-pro"  # internal alias -> gemini-3.1-pro-preview
+export GEMINI_BASE_URL="https://generativelanguage.googleapis.com/v1beta"  # optional
+```
+
+runtime 기본 경로에서는 일반 OpenAI-compatible provider를 더 이상 사용하지 않는다.
+Upstage는 내부적으로 OpenAI-compatible API 형식을 사용하지만, runtime 우선순위에서는
+명시적으로 `2순위 Upstage`로 취급한다.
 
 ### Upstage Solar Pro2 예시
 
-기본 권장 설정은 Upstage다. `UPSTAGE_API_KEY`가 있으면 client가 Upstage 경로를 우선 사용한다.
+`UPSTAGE_API_KEY`가 있으면 Upstage가 3순위 fallback provider로 추가된다.
 
 ```bash
 export UPSTAGE_API_KEY="..."

--- a/clients/__init__.py
+++ b/clients/__init__.py
@@ -1,4 +1,4 @@
 from clients.env import load_env_file
-from clients.llm import LLMClient, OpenAICompatibleClient
+from clients.llm import FallbackLLMClient, LLMClient, OpenAICompatibleClient
 
-__all__ = ["LLMClient", "OpenAICompatibleClient", "load_env_file"]
+__all__ = ["LLMClient", "OpenAICompatibleClient", "FallbackLLMClient", "load_env_file"]

--- a/clients/llm.py
+++ b/clients/llm.py
@@ -4,6 +4,7 @@ import json
 import os
 import re
 import urllib.error
+import urllib.parse
 import urllib.request
 from typing import Protocol, TypeVar
 
@@ -25,42 +26,27 @@ class LLMClient(Protocol):
         """Return a validated Pydantic model for the requested response."""
 
 
-class OpenAICompatibleClient:
-    """Minimal OpenAI-compatible JSON client for runtime execution."""
+class ProviderConfigurationError(RuntimeError):
+    """Raised when no configured provider is available."""
+
+
+class BaseStructuredClient:
+    """Shared JSON-validation loop for provider-specific LLM clients."""
+
+    provider_name = "base"
 
     def __init__(
         self,
         *,
         api_key: str,
         model: str,
-        base_url: str = "https://api.openai.com/v1",
         timeout_seconds: float = 60.0,
         max_retries: int = 1,
     ) -> None:
         self.api_key = api_key
         self.model = model
-        self.base_url = base_url.rstrip("/")
         self.timeout_seconds = timeout_seconds
         self.max_retries = max_retries
-
-    @classmethod
-    def from_env(cls) -> "OpenAICompatibleClient":
-        if os.getenv("UPSTAGE_API_KEY"):
-            api_key = os.getenv("UPSTAGE_API_KEY")
-            model = os.getenv("UPSTAGE_MODEL") or os.getenv("OPENAI_MODEL") or "solar-pro2"
-            base_url = os.getenv("UPSTAGE_BASE_URL", "https://api.upstage.ai/v1")
-            return cls(api_key=api_key, model=model, base_url=base_url)
-
-        api_key = os.getenv("OPENAI_API_KEY")
-        model = os.getenv("OPENAI_MODEL")
-        base_url = os.getenv("OPENAI_BASE_URL", "https://api.openai.com/v1")
-
-        if not api_key:
-            raise RuntimeError("Neither UPSTAGE_API_KEY nor OPENAI_API_KEY is set.")
-        if not model:
-            raise RuntimeError("OPENAI_MODEL is not set.")
-
-        return cls(api_key=api_key, model=model, base_url=base_url)
 
     def generate_json(
         self,
@@ -70,76 +56,56 @@ class OpenAICompatibleClient:
         system_prompt: str | None = None,
     ) -> ModelT:
         schema = response_model.model_json_schema()
-        messages = [
-            {
-                "role": "system",
-                "content": system_prompt
-                or "You are a structured JSON generator. Return valid JSON only.",
-            },
-            {
-                "role": "user",
-                "content": (
-                    f"{prompt}\n\n"
-                    "Return only JSON that matches this schema:\n"
-                    f"{json.dumps(schema, ensure_ascii=False, indent=2)}"
-                ),
-            },
-        ]
-
-        payload = {
-            "model": self.model,
-            "messages": messages,
-            "temperature": 0.2,
-            "response_format": {"type": "json_object"},
-        }
+        full_prompt = (
+            f"{prompt}\n\n"
+            "Return only JSON that matches this schema:\n"
+            f"{json.dumps(schema, ensure_ascii=False, indent=2)}"
+        )
 
         last_error: Exception | None = None
+        previous_response = ""
+        current_prompt = full_prompt
         for attempt in range(self.max_retries + 1):
-            content = ""
             try:
-                response_payload = self._post_json(
-                    url=f"{self.base_url}/chat/completions",
-                    payload=payload,
+                content = self._generate_content(
+                    prompt=current_prompt,
+                    system_prompt=system_prompt,
                 )
-                content = (
-                    response_payload["choices"][0]["message"]["content"]
-                    if response_payload.get("choices")
-                    else ""
-                )
+                previous_response = content
                 data = self._extract_json(content)
                 return response_model.model_validate(data)
             except (KeyError, TypeError, json.JSONDecodeError, ValidationError) as exc:
                 last_error = exc
                 if attempt < self.max_retries:
-                    payload["messages"].append(
-                        {
-                            "role": "assistant",
-                            "content": content or "{}",
-                        }
-                    )
-                    payload["messages"].append(
-                        {
-                            "role": "user",
-                            "content": self._build_retry_instruction(
-                                response_model_name=response_model.__name__,
-                                error=exc,
-                            ),
-                        }
+                    current_prompt = (
+                        f"{full_prompt}\n\n"
+                        f"Previous invalid response:\n{previous_response or '{}'}\n\n"
+                        f"{self._build_retry_instruction(response_model_name=response_model.__name__, error=exc)}"
                     )
             except urllib.error.URLError as exc:
                 last_error = exc
+                break
 
         raise RuntimeError(
-            f"Failed to generate valid {response_model.__name__} output."
+            f"{self.provider_name} failed to generate valid {response_model.__name__} output."
         ) from last_error
 
-    def _post_json(self, *, url: str, payload: dict[str, object]) -> dict[str, object]:
+    def _generate_content(self, *, prompt: str, system_prompt: str | None = None) -> str:
+        raise NotImplementedError
+
+    def _post_json(
+        self,
+        *,
+        url: str,
+        payload: dict[str, object],
+        headers: dict[str, str],
+    ) -> dict[str, object]:
         request = urllib.request.Request(
             url=url,
             method="POST",
             headers={
-                "Authorization": f"Bearer {self.api_key}",
                 "Content-Type": "application/json",
+                **headers,
             },
             data=json.dumps(payload).encode("utf-8"),
         )
@@ -174,3 +140,219 @@ class OpenAICompatibleClient:
             "Do not include keys like `$defs`, `properties`, `required`, `title`, `type`, or `additionalProperties`.\n"
             "Return JSON only."
         )
+
+
+class OpenAICompatibleClient(BaseStructuredClient):
+    """Minimal OpenAI-compatible JSON client for runtime execution."""
+
+    provider_name = "openai-compatible"
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        model: str,
+        base_url: str = "https://api.openai.com/v1",
+        timeout_seconds: float = 60.0,
+        max_retries: int = 1,
+    ) -> None:
+        super().__init__(
+            api_key=api_key,
+            model=model,
+            timeout_seconds=timeout_seconds,
+            max_retries=max_retries,
+        )
+        self.base_url = base_url.rstrip("/")
+
+    @classmethod
+    def from_env(cls) -> "OpenAICompatibleClient":
+        if os.getenv("UPSTAGE_API_KEY"):
+            api_key = os.getenv("UPSTAGE_API_KEY")
+            model = os.getenv("UPSTAGE_MODEL") or os.getenv("OPENAI_MODEL") or "solar-pro2"
+            base_url = os.getenv("UPSTAGE_BASE_URL", "https://api.upstage.ai/v1")
+            return cls(api_key=api_key, model=model, base_url=base_url)
+
+        api_key = os.getenv("OPENAI_API_KEY")
+        model = os.getenv("OPENAI_MODEL")
+        base_url = os.getenv("OPENAI_BASE_URL", "https://api.openai.com/v1")
+
+        if not api_key:
+            raise RuntimeError("Neither UPSTAGE_API_KEY nor OPENAI_API_KEY is set.")
+        if not model:
+            raise RuntimeError("OPENAI_MODEL is not set.")
+
+        return cls(api_key=api_key, model=model, base_url=base_url)
+
+    def _generate_content(self, *, prompt: str, system_prompt: str | None = None) -> str:
+        payload = {
+            "model": self.model,
+            "messages": [
+                {
+                    "role": "system",
+                    "content": system_prompt
+                    or "You are a structured JSON generator. Return valid JSON only.",
+                },
+                {
+                    "role": "user",
+                    "content": prompt,
+                },
+            ],
+            "temperature": 0.2,
+            "response_format": {"type": "json_object"},
+        }
+        response_payload = self._post_json(
+            url=f"{self.base_url}/chat/completions",
+            payload=payload,
+            headers={"Authorization": f"Bearer {self.api_key}"},
+        )
+        if not response_payload.get("choices"):
+            raise KeyError("OpenAI-compatible response is missing choices.")
+        return response_payload["choices"][0]["message"]["content"]
+
+
+class GeminiClient(BaseStructuredClient):
+    provider_name = "gemini"
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        model: str,
+        base_url: str = "https://generativelanguage.googleapis.com/v1beta",
+        timeout_seconds: float = 60.0,
+        max_retries: int = 1,
+    ) -> None:
+        super().__init__(
+            api_key=api_key,
+            model=_normalize_gemini_model(model),
+            timeout_seconds=timeout_seconds,
+            max_retries=max_retries,
+        )
+        self.base_url = base_url.rstrip("/")
+
+    def _generate_content(self, *, prompt: str, system_prompt: str | None = None) -> str:
+        payload: dict[str, object] = {
+            "contents": [
+                {
+                    "role": "user",
+                    "parts": [{"text": prompt}],
+                }
+            ],
+            "generationConfig": {
+                "temperature": 0.2,
+                "responseMimeType": "application/json",
+            },
+        }
+        if system_prompt:
+            payload["systemInstruction"] = {
+                "parts": [{"text": system_prompt}],
+            }
+
+        encoded_model = urllib.parse.quote(self.model, safe="")
+        response_payload = self._post_json(
+            url=f"{self.base_url}/models/{encoded_model}:generateContent?key={urllib.parse.quote(self.api_key, safe='')}",
+            payload=payload,
+            headers={},
+        )
+        candidates = response_payload.get("candidates")
+        if not isinstance(candidates, list) or not candidates:
+            raise KeyError("Gemini response is missing candidates.")
+        candidate = candidates[0]
+        content = candidate.get("content", {})
+        parts = content.get("parts", [])
+        if not isinstance(parts, list) or not parts:
+            raise KeyError("Gemini response is missing content parts.")
+        texts = [part.get("text", "") for part in parts if isinstance(part, dict)]
+        joined = "\n".join(text for text in texts if text)
+        if not joined:
+            raise KeyError("Gemini response did not include text content.")
+        return joined
+
+
+class UpstageClient(OpenAICompatibleClient):
+    provider_name = "upstage"
+
+
+class FallbackLLMClient:
+    """Provider-priority client with sequential failover."""
+
+    def __init__(self, providers: list[BaseStructuredClient]) -> None:
+        if not providers:
+            raise ProviderConfigurationError("No LLM providers are configured.")
+        self.providers = providers
+
+    @property
+    def provider_names(self) -> list[str]:
+        return [provider.provider_name for provider in self.providers]
+
+    @classmethod
+    def from_env(cls) -> "FallbackLLMClient":
+        providers: list[BaseStructuredClient] = []
+
+        gemini_key = os.getenv("GEMINI_API_KEY")
+        if gemini_key:
+            providers.append(
+                GeminiClient(
+                    api_key=gemini_key,
+                    model=os.getenv("GEMINI_MODEL", "gemini-3.1-pro"),
+                    base_url=os.getenv(
+                        "GEMINI_BASE_URL",
+                        "https://generativelanguage.googleapis.com/v1beta",
+                    ),
+                )
+            )
+
+        upstage_key = os.getenv("UPSTAGE_API_KEY")
+        if upstage_key:
+            providers.append(
+                UpstageClient(
+                    api_key=upstage_key,
+                    model=os.getenv("UPSTAGE_MODEL") or os.getenv("OPENAI_MODEL") or "solar-pro2",
+                    base_url=os.getenv("UPSTAGE_BASE_URL", "https://api.upstage.ai/v1"),
+                )
+            )
+
+        if not providers:
+            raise ProviderConfigurationError(
+                "No LLM provider is configured. Set GEMINI_API_KEY or UPSTAGE_API_KEY."
+            )
+
+        return cls(providers)
+
+    def generate_json(
+        self,
+        *,
+        prompt: str,
+        response_model: type[ModelT],
+        system_prompt: str | None = None,
+    ) -> ModelT:
+        errors: list[str] = []
+        last_error: Exception | None = None
+        for provider in self.providers:
+            try:
+                return provider.generate_json(
+                    prompt=prompt,
+                    response_model=response_model,
+                    system_prompt=system_prompt,
+                )
+            except Exception as exc:
+                last_error = exc
+                errors.append(f"{provider.provider_name}: {exc}")
+
+        raise RuntimeError(
+            "All configured LLM providers failed. " + " | ".join(errors)
+        ) from last_error
+def _normalize_gemini_model(model: str) -> str:
+    normalized = model.strip()
+    lowered = normalized.lower()
+    alias_map = {
+        "gemini 3.1 pro": "gemini-3.1-pro-preview",
+        "gemini-3.1-pro": "gemini-3.1-pro-preview",
+        "models/gemini-3.1-pro-preview": "gemini-3.1-pro-preview",
+        "gemini-3.1-pro-preview": "gemini-3.1-pro-preview",
+    }
+    if lowered in alias_map:
+        return alias_map[lowered]
+    if lowered.startswith("models/"):
+        return normalized.split("/", 1)[1]
+    return normalized

--- a/main.py
+++ b/main.py
@@ -5,7 +5,7 @@ import json
 from pathlib import Path
 
 from clients.env import load_env_file
-from clients.llm import OpenAICompatibleClient
+from clients.llm import FallbackLLMClient
 from loaders import load_input_intake
 from orchestrator.pipeline import ImplementationPipeline
 from schemas.planning_package import ValidationStatus
@@ -59,7 +59,7 @@ def main() -> int:
                 print(f"- {issue.code}: {issue.message}")
             return 1
         implementation_spec = input_intake_result.implementation_spec
-    llm_client = OpenAICompatibleClient.from_env()
+    llm_client = FallbackLLMClient.from_env()
     pipeline = ImplementationPipeline(
         llm_client=llm_client,
         spec_path=input_path,

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1,28 +1,54 @@
 from __future__ import annotations
 
-from clients.llm import OpenAICompatibleClient
+from clients.llm import FallbackLLMClient, OpenAICompatibleClient
 
 
-def test_from_env_prefers_upstage_settings(monkeypatch) -> None:
+def test_fallback_client_prefers_gemini_then_upstage(monkeypatch) -> None:
+    monkeypatch.setenv("GEMINI_API_KEY", "gemini-key")
+    monkeypatch.setenv("GEMINI_MODEL", "gemini-3.1-pro")
+    monkeypatch.setenv("UPSTAGE_API_KEY", "upstage-key")
+    monkeypatch.setenv("UPSTAGE_MODEL", "solar-pro2")
+
+    client = FallbackLLMClient.from_env()
+
+    assert client.provider_names == ["gemini", "upstage"]
+    assert client.providers[0].model == "gemini-3.1-pro-preview"
+    assert client.providers[1].model == "solar-pro2"
+
+
+def test_fallback_client_uses_defaults_for_gemini_and_upstage(monkeypatch) -> None:
+    monkeypatch.setenv("GEMINI_API_KEY", "gemini-key")
+    monkeypatch.delenv("GEMINI_MODEL", raising=False)
+    monkeypatch.setenv("UPSTAGE_API_KEY", "upstage-key")
+    monkeypatch.delenv("UPSTAGE_MODEL", raising=False)
+    monkeypatch.delenv("OPENAI_MODEL", raising=False)
+
+    client = FallbackLLMClient.from_env()
+
+    assert client.provider_names == ["gemini", "upstage"]
+    assert client.providers[0].model == "gemini-3.1-pro-preview"
+    assert client.providers[1].model == "solar-pro2"
+
+
+def test_fallback_client_requires_gemini_or_upstage(monkeypatch) -> None:
+    monkeypatch.delenv("GEMINI_API_KEY", raising=False)
+    monkeypatch.delenv("UPSTAGE_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    monkeypatch.delenv("OPENAI_MODEL", raising=False)
+
+    try:
+        FallbackLLMClient.from_env()
+        assert False, "Expected provider configuration error"
+    except RuntimeError as exc:
+        assert "GEMINI_API_KEY or UPSTAGE_API_KEY" in str(exc)
+
+
+def test_openai_compatible_client_from_env_prefers_upstage_settings(monkeypatch) -> None:
     monkeypatch.setenv("UPSTAGE_API_KEY", "test-upstage-key")
     monkeypatch.setenv("UPSTAGE_MODEL", "solar-pro2")
     monkeypatch.setenv("UPSTAGE_BASE_URL", "https://api.upstage.ai/v1")
     monkeypatch.setenv("OPENAI_API_KEY", "test-openai-key")
     monkeypatch.setenv("OPENAI_MODEL", "ignored-model")
-
-    client = OpenAICompatibleClient.from_env()
-
-    assert client.api_key == "test-upstage-key"
-    assert client.model == "solar-pro2"
-    assert client.base_url == "https://api.upstage.ai/v1"
-
-
-def test_from_env_uses_upstage_defaults(monkeypatch) -> None:
-    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
-    monkeypatch.delenv("OPENAI_MODEL", raising=False)
-    monkeypatch.setenv("UPSTAGE_API_KEY", "test-upstage-key")
-    monkeypatch.delenv("UPSTAGE_MODEL", raising=False)
-    monkeypatch.delenv("UPSTAGE_BASE_URL", raising=False)
 
     client = OpenAICompatibleClient.from_env()
 


### PR DESCRIPTION
## Summary
- runtime LLM provider 우선순위를 `Gemini -> Upstage`로 정리합니다.
- 기존 단일 OpenAI-compatible client 경로를 `FallbackLLMClient`로 교체합니다.
- `gemini-3.1-pro` 입력값을 실제 API slug인 `gemini-3.1-pro-preview`로 정규화합니다.

## Changes
- `clients/llm.py`
  - `FallbackLLMClient` 추가
  - `GeminiClient`, `UpstageClient` 추가
  - Claude 경로 제거
- `main.py`
  - `FallbackLLMClient.from_env()` 사용
- `tests/test_llm_client.py`
  - provider 우선순위 및 모델 정규화 테스트 추가
- `README.md`
  - 환경변수 설정과 fallback 우선순위 문서화

## Verification
- `python -m pytest -q` -> `72 passed`
- provider probe
  - Gemini: PASS
  - Upstage: PASS

## Notes
- `.env`는 로컬에서만 수정하며 커밋하지 않습니다.
- runtime 기본 경로에서는 Claude와 일반 OpenAI-compatible provider를 사용하지 않습니다.
