### PR TITLE
Builder repair를 patch-oriented로 개선한다

### DIFF
--- a/agents/implementation/prototype_builder_agent.py
+++ b/agents/implementation/prototype_builder_agent.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import ast
 import json
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 
 from clients.llm import LLMClient
@@ -39,6 +39,19 @@ INVALID_STREAMLIT_API = "INVALID_STREAMLIT_API"
 PYTHON_SYNTAX_INVALID = "PYTHON_SYNTAX_INVALID"
 MISSING_CONTENT_GUIDANCE = "MISSING_CONTENT_GUIDANCE"
 PLANNING_PACKAGE_RUNTIME_ACCESS = "PLANNING_PACKAGE_RUNTIME_ACCESS"
+MAX_BUILDER_REPAIR_ATTEMPTS = 2
+REPAIR_FRIENDLY_CODES = {
+    CONTRACT_MISSING_MARKER,
+    RESULT_FLOW_MISSING,
+    BATTLE_FLOW_MISSING,
+    COACHING_FLOW_MISSING,
+    INTERACTION_UNITS_RUNTIME_MISSING,
+    LEGACY_QUEST_RUNTIME_ACCESS,
+    ROOT_FIRST_CONTENT_LOADING,
+    RAW_FIELD_ACCESS,
+    INVALID_STREAMLIT_API,
+    MISSING_CONTENT_GUIDANCE,
+}
 
 
 @dataclass(frozen=True)
@@ -107,6 +120,37 @@ class InvalidAppSourceError(ValueError):
         self.contract_items = contract_items or []
 
 
+@dataclass(frozen=True)
+class ValidatedAppSourceResult:
+    app_source: str
+    generation_notes: list[str]
+    reflection_attempts: int = 0
+    repair_attempted: bool = False
+    initial_validation_error_code: str = ""
+    repair_validation_error_code: str = ""
+    repair_history: list[str] = field(default_factory=list)
+
+
+class BuilderRepairFailed(RuntimeError):
+    def __init__(
+        self,
+        final_error: InvalidAppSourceError,
+        *,
+        reflection_attempts: int,
+        repair_attempted: bool,
+        initial_validation_error_code: str,
+        repair_validation_error_code: str,
+        repair_history: list[str],
+    ) -> None:
+        super().__init__(final_error.message)
+        self.final_error = final_error
+        self.reflection_attempts = reflection_attempts
+        self.repair_attempted = repair_attempted
+        self.initial_validation_error_code = initial_validation_error_code
+        self.repair_validation_error_code = repair_validation_error_code
+        self.repair_history = repair_history
+
+
 def run_prototype_builder_agent(
     input_model: PrototypeBuilderInput,
     llm_client: LLMClient,
@@ -156,6 +200,11 @@ def run_prototype_builder_agent(
     fallback_used = False
     fallback_reason = ""
     generation_mode = "llm_generated"
+    reflection_attempts = 0
+    repair_attempted = False
+    initial_validation_error_code = ""
+    repair_validation_error_code = ""
+    repair_history: list[str] = []
 
     runtime_notes = [
         f"app.py는 outputs/{content_filename}을 읽는다.",
@@ -166,25 +215,47 @@ def run_prototype_builder_agent(
     ]
 
     try:
-        app_source, generation_notes = _generate_validated_app_source_with_llm(
+        generation_result = _generate_validated_app_source_with_llm(
             input_model=input_model,
             llm_client=llm_client,
             content_filename=content_filename,
             package_context=package_context,
             builder_runtime_contract=builder_runtime_contract,
         )
-        runtime_notes.extend(generation_notes)
+        app_source = generation_result.app_source
+        runtime_notes.extend(generation_result.generation_notes)
+        reflection_attempts = generation_result.reflection_attempts
+        repair_attempted = generation_result.repair_attempted
+        initial_validation_error_code = generation_result.initial_validation_error_code
+        repair_validation_error_code = generation_result.repair_validation_error_code
+        repair_history = generation_result.repair_history
         runtime_notes.append(
             f"Builder runtime contract satisfied: {builder_runtime_contract.to_summary_string()}."
         )
         runtime_notes.append("app.py는 LLM 생성 결과를 사용했다.")
-    except InvalidAppSourceError as exc:
-        builder_errors.extend([LLM_OUTPUT_INVALID, exc.code, FALLBACK_USED])
+    except BuilderRepairFailed as exc:
+        builder_errors.extend(
+            _dedupe_preserve_order(
+                [
+                    LLM_OUTPUT_INVALID,
+                    exc.initial_validation_error_code,
+                    exc.repair_validation_error_code,
+                    FALLBACK_USED,
+                ]
+            )
+        )
         fallback_used = True
-        fallback_reason = f"{LLM_OUTPUT_INVALID}: {exc.code}: {exc.message}"
+        fallback_reason = (
+            f"{LLM_OUTPUT_INVALID}: {exc.final_error.code}: {exc.final_error.message}"
+        )
         generation_mode = "fallback_template"
         app_source = build_fallback_app_source(input_model)
         runtime_notes.append("LLM app.py 출력이 유효하지 않아 fallback template을 사용했다.")
+        reflection_attempts = exc.reflection_attempts
+        repair_attempted = exc.repair_attempted
+        initial_validation_error_code = exc.initial_validation_error_code
+        repair_validation_error_code = exc.repair_validation_error_code
+        repair_history = exc.repair_history
     except Exception as exc:
         builder_errors.extend([LLM_CALL_FAILED, FALLBACK_USED])
         fallback_used = True
@@ -207,6 +278,8 @@ def run_prototype_builder_agent(
         integration_notes.append(
             "Fallback template 사용은 LLM-generated app.py 성공으로 간주하지 않는다."
         )
+    if repair_history:
+        runtime_notes.extend(repair_history)
 
     return PrototypeBuilderOutput(
         agent=make_label(
@@ -231,7 +304,11 @@ def run_prototype_builder_agent(
         fallback_used=fallback_used,
         fallback_reason=fallback_reason,
         generation_inputs_summary=generation_inputs_summary,
-        reflection_attempts=0,
+        reflection_attempts=reflection_attempts,
+        repair_attempted=repair_attempted,
+        initial_validation_error_code=initial_validation_error_code,
+        repair_validation_error_code=repair_validation_error_code,
+        repair_history=repair_history,
         builder_errors=builder_errors,
     )
 
@@ -305,7 +382,7 @@ def _generate_validated_app_source_with_llm(
     content_filename: str,
     package_context: dict[str, str],
     builder_runtime_contract: BuilderRuntimeContract,
-) -> tuple[str, list[str]]:
+) -> ValidatedAppSourceResult:
     generated_app = _generate_app_source_with_llm(
         input_model=input_model,
         llm_client=llm_client,
@@ -319,9 +396,9 @@ def _generate_validated_app_source_with_llm(
             content_filename=content_filename,
             builder_runtime_contract=builder_runtime_contract,
         )
-        return (
-            validated_source,
-            _dedupe_preserve_order(
+        return ValidatedAppSourceResult(
+            app_source=validated_source,
+            generation_notes=_dedupe_preserve_order(
                 [
                     *generated_app.generation_notes,
                     _build_contract_self_check_note(validated_source, builder_runtime_contract),
@@ -329,37 +406,155 @@ def _generate_validated_app_source_with_llm(
             ),
         )
     except InvalidAppSourceError as first_error:
+        return _repair_invalid_app_source_with_llm(
+            input_model=input_model,
+            llm_client=llm_client,
+            content_filename=content_filename,
+            invalid_source=generated_app.app_source,
+            first_error=first_error,
+            generated_app=generated_app,
+            builder_runtime_contract=builder_runtime_contract,
+        )
+
+
+def _repair_invalid_app_source_with_llm(
+    *,
+    input_model: PrototypeBuilderInput,
+    llm_client: LLMClient,
+    content_filename: str,
+    invalid_source: str,
+    first_error: InvalidAppSourceError,
+    generated_app: AppSourceGenerationOutput,
+    builder_runtime_contract: BuilderRuntimeContract,
+) -> ValidatedAppSourceResult:
+    repair_history = [
+        _format_repair_history_entry(
+            attempt_number=0,
+            error=first_error,
+            status="FAILED",
+            note="Initial generation failed validation.",
+        )
+    ]
+    if not _is_repair_friendly_error(first_error):
+        raise BuilderRepairFailed(
+            first_error,
+            reflection_attempts=0,
+            repair_attempted=False,
+            initial_validation_error_code=first_error.code,
+            repair_validation_error_code="",
+            repair_history=repair_history + ["Repair skipped: failure was not repair-friendly."],
+        )
+
+    previous_error = first_error
+    current_invalid_source = invalid_source
+    repair_attempts = 0
+    generation_notes = list(generated_app.generation_notes)
+
+    for attempt_number in range(1, MAX_BUILDER_REPAIR_ATTEMPTS + 1):
+        repair_attempts = attempt_number
         repair_prompt = _build_app_validation_repair_prompt(
             input_model=input_model,
             content_filename=content_filename,
-            invalid_source=generated_app.app_source,
-            validation_error=first_error,
+            invalid_source=current_invalid_source,
+            validation_error=previous_error,
             builder_runtime_contract=builder_runtime_contract,
+            repair_attempt_number=attempt_number,
+            max_repair_attempts=MAX_BUILDER_REPAIR_ATTEMPTS,
+            repair_history=repair_history,
         )
-        repaired_app = llm_client.generate_json(
-            prompt=repair_prompt,
-            response_model=AppSourceGenerationOutput,
-            system_prompt=(
-                "You fix one generated Streamlit app.py so it satisfies the runtime contract. "
-                "Return JSON only. Do not call external LLM APIs."
-            ),
-        )
-        repaired_source = _validate_generated_app_source(
-            generated_app=repaired_app,
-            content_filename=content_filename,
-            builder_runtime_contract=builder_runtime_contract,
-        )
-        return (
-            repaired_source,
-            _dedupe_preserve_order(
-                [
-                    *generated_app.generation_notes,
-                    f"Initial app_source failed validation once with {first_error.code}.",
-                    *repaired_app.generation_notes,
-                    _build_contract_self_check_note(repaired_source, builder_runtime_contract),
-                ]
-            ),
-        )
+        try:
+            repaired_app = llm_client.generate_json(
+                prompt=repair_prompt,
+                response_model=AppSourceGenerationOutput,
+                system_prompt=(
+                    "You fix one generated Streamlit app.py so it satisfies the runtime contract. "
+                    "Return JSON only. Do not call external LLM APIs."
+                ),
+            )
+        except Exception as exc:
+            repair_history.append(
+                f"Repair attempt {attempt_number} failed before validation: LLM_CALL_FAILED ({exc})."
+            )
+            raise BuilderRepairFailed(
+                InvalidAppSourceError(LLM_CALL_FAILED, f"Repair attempt {attempt_number} LLM call failed: {exc}."),
+                reflection_attempts=repair_attempts,
+                repair_attempted=True,
+                initial_validation_error_code=first_error.code,
+                repair_validation_error_code=LLM_CALL_FAILED,
+                repair_history=repair_history,
+            ) from exc
+
+        try:
+            repaired_source = _validate_generated_app_source(
+                generated_app=repaired_app,
+                content_filename=content_filename,
+                builder_runtime_contract=builder_runtime_contract,
+            )
+            repair_history.append(
+                f"Repair attempt {attempt_number} succeeded after {previous_error.code}."
+            )
+            return ValidatedAppSourceResult(
+                app_source=repaired_source,
+                generation_notes=_dedupe_preserve_order(
+                    [
+                        *generation_notes,
+                        f"Initial app_source failed validation once with {first_error.code}.",
+                        *repaired_app.generation_notes,
+                        _build_contract_self_check_note(repaired_source, builder_runtime_contract),
+                    ]
+                ),
+                reflection_attempts=repair_attempts,
+                repair_attempted=True,
+                initial_validation_error_code=first_error.code,
+                repair_validation_error_code="",
+                repair_history=repair_history,
+            )
+        except InvalidAppSourceError as repair_error:
+            repair_history.append(
+                _format_repair_history_entry(
+                    attempt_number=attempt_number,
+                    error=repair_error,
+                    status="FAILED",
+                    note=f"Repair attempt {attempt_number} failed validation.",
+                )
+            )
+            stop_reason = _repair_stop_reason(previous_error, repair_error)
+            if stop_reason:
+                repair_history.append(
+                    f"Repair stopped after attempt {attempt_number}: {stop_reason}"
+                )
+                raise BuilderRepairFailed(
+                    repair_error,
+                    reflection_attempts=repair_attempts,
+                    repair_attempted=True,
+                    initial_validation_error_code=first_error.code,
+                    repair_validation_error_code=repair_error.code,
+                    repair_history=repair_history,
+                )
+            if not _is_repair_friendly_error(repair_error):
+                repair_history.append(
+                    f"Repair stopped after attempt {attempt_number}: failure was not repair-friendly."
+                )
+                raise BuilderRepairFailed(
+                    repair_error,
+                    reflection_attempts=repair_attempts,
+                    repair_attempted=True,
+                    initial_validation_error_code=first_error.code,
+                    repair_validation_error_code=repair_error.code,
+                    repair_history=repair_history,
+                )
+            previous_error = repair_error
+            current_invalid_source = repaired_app.app_source
+
+    raise BuilderRepairFailed(
+        previous_error,
+        reflection_attempts=repair_attempts,
+        repair_attempted=repair_attempts > 0,
+        initial_validation_error_code=first_error.code,
+        repair_validation_error_code=previous_error.code,
+        repair_history=repair_history
+        + [f"Repair budget exhausted after {repair_attempts} attempts."],
+    )
 
 
 def _build_app_generation_prompt(
@@ -437,19 +632,29 @@ def _build_app_validation_repair_prompt(
     invalid_source: str,
     validation_error: InvalidAppSourceError,
     builder_runtime_contract: BuilderRuntimeContract,
+    repair_attempt_number: int,
+    max_repair_attempts: int,
+    repair_history: list[str],
 ) -> str:
     spec = input_model.implementation_spec
     failed_items = validation_error.contract_items or [validation_error.message]
     return (
         "The previous generated app.py failed validation.\n"
+        f"Repair attempt: {repair_attempt_number} / {max_repair_attempts}\n"
         f"Validation error code: {validation_error.code}\n"
         f"Validation error: {validation_error.message}\n\n"
-        "Preserve the valid parts of the existing source and add or fix the missing runtime contract items.\n"
-        "Do not drop valid helper functions, content loading logic, or current_screen transitions.\n\n"
+        "Preserve the valid parts of the existing source and add or fix only the missing runtime contract items.\n"
+        "Modify the smallest possible set of lines.\n"
+        "Do not rewrite unrelated functions.\n"
+        "Do not drop valid helper functions, content loading logic, or current_screen transitions.\n"
+        "Do not rename screen constants, helper functions, or session state keys.\n"
+        "If a missing contract item is shown as a literal assignment or literal marker, insert that exact literal.\n\n"
         "Builder runtime contract:\n"
         f"{builder_runtime_contract.to_prompt_block()}\n\n"
         "Missing or invalid contract items:\n"
         f"{json.dumps(failed_items, ensure_ascii=False, indent=2)}\n\n"
+        "Repair history so far:\n"
+        f"{json.dumps(repair_history, ensure_ascii=False, indent=2)}\n\n"
         "Required functions to preserve:\n"
         f"{json.dumps(builder_runtime_contract.required_functions, ensure_ascii=False)}\n\n"
         "Targeted repair guidance:\n"
@@ -464,6 +669,39 @@ def _build_app_validation_repair_prompt(
         f"content_filename: {content_filename}\n\n"
         "Previous invalid app_source:\n"
         f"{invalid_source}"
+    )
+
+
+def _is_repair_friendly_error(error: InvalidAppSourceError) -> bool:
+    contract_items = error.contract_items or [error.message]
+    return error.code in REPAIR_FRIENDLY_CODES and len(contract_items) <= 2
+
+
+def _repair_stop_reason(
+    previous_error: InvalidAppSourceError,
+    current_error: InvalidAppSourceError,
+) -> str:
+    previous_items = previous_error.contract_items or [previous_error.message]
+    current_items = current_error.contract_items or [current_error.message]
+    if current_error.code == previous_error.code:
+        return f"same validation error code repeated ({current_error.code})"
+    if current_items == previous_items:
+        return "contract items did not change between repair attempts"
+    return ""
+
+
+def _format_repair_history_entry(
+    *,
+    attempt_number: int,
+    error: InvalidAppSourceError,
+    status: str,
+    note: str,
+) -> str:
+    contract_items = ", ".join(error.contract_items or []) or "none"
+    label = "initial_validation" if attempt_number == 0 else f"repair_attempt_{attempt_number}"
+    return (
+        f"{label}: {status} code={error.code}; "
+        f"contract_items=[{contract_items}]; note={note}"
     )
 
 

--- a/schemas/implementation/prototype_builder.py
+++ b/schemas/implementation/prototype_builder.py
@@ -82,7 +82,23 @@ class PrototypeBuilderOutput(SchemaModel):
     )
     reflection_attempts: int = Field(
         default=0,
-        description="Number of patch/reflection attempts applied after local checks.",
+        description="Number of Builder repair attempts and downstream patch/reflection attempts.",
+    )
+    repair_attempted: bool = Field(
+        default=False,
+        description="Whether the Builder attempted at least one in-agent repair before fallback or success.",
+    )
+    initial_validation_error_code: str = Field(
+        default="",
+        description="First Builder validation error code observed before any repair attempt.",
+    )
+    repair_validation_error_code: str = Field(
+        default="",
+        description="Last Builder validation error code observed during repair attempts, if any.",
+    )
+    repair_history: list[str] = Field(
+        default_factory=list,
+        description="Short per-attempt repair history entries emitted by the Builder.",
     )
     builder_errors: list[str] = Field(
         default_factory=list,

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -33,6 +33,7 @@ class FakeLLMClient:
         fail_app_generation: bool = False,
         invalid_app_generation: bool = False,
         patch_source: str | None = None,
+        repair_sources: list[str] | None = None,
         no_patch: bool = False,
         weak_spec_first_pass: bool = False,
         weak_requirement_first_pass: bool = False,
@@ -45,6 +46,7 @@ class FakeLLMClient:
         self.fail_app_generation = fail_app_generation
         self.invalid_app_generation = invalid_app_generation
         self.patch_source = patch_source
+        self.repair_sources = list(repair_sources or [])
         self.no_patch = no_patch
         self.weak_spec_first_pass = weak_spec_first_pass
         self.weak_requirement_first_pass = weak_requirement_first_pass
@@ -380,10 +382,16 @@ class FakeLLMClient:
                 if _prompt_requires_v2_builder_contract(prompt)
                 else _build_llm_generated_streamlit_source(content_filename)
             )
+            is_repair_prompt = "The previous generated app.py failed validation." in prompt
+            repair_source = None
+            if is_repair_prompt and self.repair_sources:
+                repair_source = self.repair_sources.pop(0)
+            elif is_repair_prompt and self.patch_source is not None:
+                repair_source = self.patch_source
             return response_model.model_validate(
                 {
                     "app_path": "app.py",
-                    "app_source": self.app_source or default_source,
+                    "app_source": repair_source or self.app_source or default_source,
                     "generation_notes": ["fake LLM generated deterministic Streamlit app.py"],
                 }
             )

--- a/tests/test_prototype_builder_agent.py
+++ b/tests/test_prototype_builder_agent.py
@@ -8,7 +8,7 @@ from agents.implementation.prototype_builder_agent import (
     run_prototype_builder_agent,
 )
 from loaders import load_input_intake, load_planning_package, planning_package_to_implementation_spec
-from orchestrator.app_source import build_content_filename
+from orchestrator.app_source import build_content_filename, build_streamlit_app_source
 from schemas.implementation.content_interaction import ContentInteractionOutput
 from schemas.implementation.prototype_builder import PrototypeBuilderInput
 from schemas.implementation.requirement_mapping import RequirementMappingOutput
@@ -45,6 +45,34 @@ def _build_package_content_output(
 
 def _extract_function_block(source: str, name: str, next_name: str) -> str:
     return source.split(f"def {name}", 1)[1].split(f"def {next_name}", 1)[0]
+
+
+def _build_chatbot_builder_input(fake: FakeLLMClient) -> PrototypeBuilderInput:
+    intake_result = load_input_intake(CHATBOT_PACKAGE_DIR)
+    assert intake_result.implementation_spec is not None
+    spec = intake_result.implementation_spec
+    content_output = fake.generate_json(
+        prompt="\n".join(
+            [
+                f"- service_name: {spec.service_name}",
+                f"- content_types: {json.dumps(spec.core_features, ensure_ascii=False)}",
+                f"- learning_goals: {json.dumps(spec.learning_goals, ensure_ascii=False)}",
+                f"- total_count: {spec.total_count}",
+                "- items_per_type: 0",
+                "- interaction_mode: coaching",
+            ]
+        ),
+        response_model=ContentInteractionOutput,
+    )
+    return PrototypeBuilderInput(
+        spec_intake_output=fake.generate_json(prompt="", response_model=SpecIntakeOutput),
+        requirement_mapping_output=fake.generate_json(
+            prompt="",
+            response_model=RequirementMappingOutput,
+        ),
+        content_interaction_output=content_output,
+        implementation_spec=spec,
+    )
 
 
 def test_prototype_builder_materializes_llm_generated_app_from_planning_package() -> None:
@@ -254,6 +282,101 @@ def test_general_mode_without_items_does_not_force_coaching_runtime_contract() -
     assert "api_chat_submit" not in contract.required_functions
     assert "SCREEN_FOLLOW_UP" not in contract.required_screen_constants
     assert "SCREEN_MULTIPLE_CHOICE_RESULT" in contract.required_screen_constants
+
+
+def test_prototype_builder_repairs_single_missing_marker_without_fallback() -> None:
+    fake = FakeLLMClient()
+    builder_input = _build_chatbot_builder_input(fake)
+    spec = builder_input.implementation_spec
+    content_filename = build_content_filename(spec.service_name)
+    valid_source = build_streamlit_app_source(
+        spec.service_name,
+        content_filename,
+        interaction_mode="coaching",
+    )
+    invalid_source = valid_source.replace(
+        '        st.session_state.current_screen = SCREEN_ERROR\n',
+        "",
+        1,
+    )
+    repair_fake = FakeLLMClient(app_source=invalid_source, patch_source=valid_source)
+
+    output = run_prototype_builder_agent(builder_input, repair_fake)
+
+    assert output.generation_mode == "llm_generated"
+    assert output.fallback_used is False
+    assert output.reflection_attempts == 1
+    assert output.repair_attempted is True
+    assert output.initial_validation_error_code == "COACHING_FLOW_MISSING"
+    assert output.repair_validation_error_code == ""
+    assert any("Repair attempt 1 succeeded" in entry for entry in output.repair_history)
+
+
+def test_prototype_builder_stops_early_when_same_error_repeats() -> None:
+    fake = FakeLLMClient()
+    builder_input = _build_chatbot_builder_input(fake)
+    spec = builder_input.implementation_spec
+    content_filename = build_content_filename(spec.service_name)
+    valid_source = build_streamlit_app_source(
+        spec.service_name,
+        content_filename,
+        interaction_mode="coaching",
+    )
+    invalid_source = valid_source.replace(
+        '        st.session_state.current_screen = SCREEN_ERROR\n',
+        "",
+        1,
+    )
+    repair_fake = FakeLLMClient(
+        app_source=invalid_source,
+        repair_sources=[invalid_source, valid_source],
+    )
+
+    output = run_prototype_builder_agent(builder_input, repair_fake)
+
+    assert output.generation_mode == "fallback_template"
+    assert output.fallback_used is True
+    assert output.reflection_attempts == 1
+    assert output.repair_attempted is True
+    assert output.initial_validation_error_code == "COACHING_FLOW_MISSING"
+    assert output.repair_validation_error_code == "COACHING_FLOW_MISSING"
+    assert any("same validation error code repeated" in entry for entry in output.repair_history)
+
+
+def test_prototype_builder_allows_second_repair_when_failure_changes() -> None:
+    fake = FakeLLMClient()
+    builder_input = _build_chatbot_builder_input(fake)
+    spec = builder_input.implementation_spec
+    content_filename = build_content_filename(spec.service_name)
+    valid_source = build_streamlit_app_source(
+        spec.service_name,
+        content_filename,
+        interaction_mode="coaching",
+    )
+    root_first_source = valid_source.replace(
+        "CONTENT_CANDIDATE_PATHS = [OUTPUT_PATH, FALLBACK_OUTPUT_PATH]",
+        "CONTENT_CANDIDATE_PATHS = [FALLBACK_OUTPUT_PATH, OUTPUT_PATH]",
+        1,
+    )
+    missing_error_transition_source = valid_source.replace(
+        '        st.session_state.current_screen = SCREEN_ERROR\n',
+        "",
+        1,
+    )
+    repair_fake = FakeLLMClient(
+        app_source=root_first_source,
+        repair_sources=[missing_error_transition_source, valid_source],
+    )
+
+    output = run_prototype_builder_agent(builder_input, repair_fake)
+
+    assert output.generation_mode == "llm_generated"
+    assert output.fallback_used is False
+    assert output.reflection_attempts == 2
+    assert output.repair_attempted is True
+    assert output.initial_validation_error_code == "ROOT_FIRST_CONTENT_LOADING"
+    assert len(output.repair_history) >= 3
+    assert any("Repair attempt 2 succeeded" in entry for entry in output.repair_history)
 
 
 def test_prototype_builder_uses_fallback_when_llm_call_fails() -> None:


### PR DESCRIPTION
## Summary
- Prototype Builder repair를 full-regeneration 성격의 1회 재생성에서 patch-oriented repair로 개선했습니다.
- 총 생성 시도 수를 `initial 1회 + repair 최대 2회`로 늘리고, 같은 validation error가 반복되면 조기 중단하도록 했습니다.
- repair telemetry를 `PrototypeBuilderOutput`에 남기도록 보강했습니다.

## What changed
- `PrototypeBuilderOutput`에 아래 필드를 추가했습니다.
  - `repair_attempted`
  - `initial_validation_error_code`
  - `repair_validation_error_code`
  - `repair_history`
- Builder 내부 repair 로직을 아래 정책으로 변경했습니다.
  - repair-friendly failure만 다회 repair 시도
  - 최대 repair 2회
  - 동일 error code 반복 시 조기 중단
  - contract item이 바뀌지 않으면 조기 중단
- repair prompt를 더 patch-oriented하게 강화했습니다.
  - 기존 source 유지
  - 최소 수정
  - literal contract item은 exact literal로 추가/수정
- Fake LLM과 단위 테스트를 확장해 다음 시나리오를 검증했습니다.
  - single missing marker repair 성공
  - repeated same-error 조기 중단
  - 2차 repair 성공

## Test
- `python -m pytest -q tests/test_prototype_builder_agent.py`
- `python -m pytest -q tests/test_orchestrator.py tests/test_content_interaction_semantics.py`
- `python -m pytest -q`

All passed: `83 passed`

Closes #47
