### PR TITLE
Prototype Builder를 plan -> code 2단계 생성으로 전환한다

### DIFF
--- a/agents/implementation/prototype_builder_agent.py
+++ b/agents/implementation/prototype_builder_agent.py
@@ -13,6 +13,7 @@ from loaders import load_planning_package
 from orchestrator.app_source import build_content_filename, build_streamlit_app_source
 from schemas.implementation.common import GeneratedFile
 from schemas.implementation.prototype_builder import (
+    AppFlowPlanOutput,
     AppSourceGenerationOutput,
     PrototypeBuilderInput,
     PrototypeBuilderOutput,
@@ -39,7 +40,16 @@ INVALID_STREAMLIT_API = "INVALID_STREAMLIT_API"
 PYTHON_SYNTAX_INVALID = "PYTHON_SYNTAX_INVALID"
 MISSING_CONTENT_GUIDANCE = "MISSING_CONTENT_GUIDANCE"
 PLANNING_PACKAGE_RUNTIME_ACCESS = "PLANNING_PACKAGE_RUNTIME_ACCESS"
+PLAN_LOADING_ORDER_INVALID = "PLAN_LOADING_ORDER_INVALID"
+PLAN_CONTENT_RUNTIME_SOURCE_INVALID = "PLAN_CONTENT_RUNTIME_SOURCE_INVALID"
+PLAN_SCREENS_MISSING = "PLAN_SCREENS_MISSING"
+PLAN_TRANSITIONS_MISSING = "PLAN_TRANSITIONS_MISSING"
+PLAN_FUNCTIONS_MISSING = "PLAN_FUNCTIONS_MISSING"
+PLAN_RUNTIME_LITERAL_MISSING = "PLAN_RUNTIME_LITERAL_MISSING"
+PLAN_ERROR_PATH_MISSING = "PLAN_ERROR_PATH_MISSING"
+PLAN_RESULT_PATH_MISSING = "PLAN_RESULT_PATH_MISSING"
 MAX_BUILDER_REPAIR_ATTEMPTS = 2
+MAX_PLAN_REPAIR_ATTEMPTS = 2
 REPAIR_FRIENDLY_CODES = {
     CONTRACT_MISSING_MARKER,
     RESULT_FLOW_MISSING,
@@ -50,7 +60,18 @@ REPAIR_FRIENDLY_CODES = {
     ROOT_FIRST_CONTENT_LOADING,
     RAW_FIELD_ACCESS,
     INVALID_STREAMLIT_API,
+    PYTHON_SYNTAX_INVALID,
     MISSING_CONTENT_GUIDANCE,
+}
+PLAN_REPAIR_FRIENDLY_CODES = {
+    PLAN_LOADING_ORDER_INVALID,
+    PLAN_CONTENT_RUNTIME_SOURCE_INVALID,
+    PLAN_SCREENS_MISSING,
+    PLAN_TRANSITIONS_MISSING,
+    PLAN_FUNCTIONS_MISSING,
+    PLAN_RUNTIME_LITERAL_MISSING,
+    PLAN_ERROR_PATH_MISSING,
+    PLAN_RESULT_PATH_MISSING,
 }
 
 
@@ -120,6 +141,33 @@ class InvalidAppSourceError(ValueError):
         self.contract_items = contract_items or []
 
 
+class InvalidAppFlowPlanError(ValueError):
+    """Raised when the intermediate AppFlowPlan does not satisfy the runtime contract."""
+
+    def __init__(
+        self,
+        code: str,
+        message: str,
+        *,
+        contract_items: list[str] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.message = message
+        self.contract_items = contract_items or []
+
+
+@dataclass(frozen=True)
+class ValidatedAppFlowPlanResult:
+    plan: AppFlowPlanOutput
+    generation_notes: list[str]
+    repair_attempts: int = 0
+    repair_attempted: bool = False
+    initial_validation_error_code: str = ""
+    repair_validation_error_code: str = ""
+    repair_history: list[str] = field(default_factory=list)
+
+
 @dataclass(frozen=True)
 class ValidatedAppSourceResult:
     app_source: str
@@ -129,6 +177,26 @@ class ValidatedAppSourceResult:
     initial_validation_error_code: str = ""
     repair_validation_error_code: str = ""
     repair_history: list[str] = field(default_factory=list)
+
+
+class BuilderPlanRepairFailed(RuntimeError):
+    def __init__(
+        self,
+        final_error: InvalidAppFlowPlanError,
+        *,
+        repair_attempts: int,
+        repair_attempted: bool,
+        initial_validation_error_code: str,
+        repair_validation_error_code: str,
+        repair_history: list[str],
+    ) -> None:
+        super().__init__(final_error.message)
+        self.final_error = final_error
+        self.repair_attempts = repair_attempts
+        self.repair_attempted = repair_attempted
+        self.initial_validation_error_code = initial_validation_error_code
+        self.repair_validation_error_code = repair_validation_error_code
+        self.repair_history = repair_history
 
 
 class BuilderRepairFailed(RuntimeError):
@@ -200,6 +268,11 @@ def run_prototype_builder_agent(
     fallback_used = False
     fallback_reason = ""
     generation_mode = "llm_generated"
+    generation_stage = "plan_then_code"
+    plan_validation_passed = False
+    plan_repair_attempts = 0
+    plan_summary: list[str] = []
+    app_flow_plan: dict[str, object] = {}
     reflection_attempts = 0
     repair_attempted = False
     initial_validation_error_code = ""
@@ -215,12 +288,31 @@ def run_prototype_builder_agent(
     ]
 
     try:
+        plan_result = _generate_validated_app_flow_plan_with_llm(
+            input_model=input_model,
+            llm_client=llm_client,
+            content_filename=content_filename,
+            package_context=package_context,
+            builder_runtime_contract=builder_runtime_contract,
+        )
+        plan_validation_passed = True
+        plan_repair_attempts = plan_result.repair_attempts
+        plan_summary = _build_plan_summary(
+            plan_result.plan,
+            builder_runtime_contract=builder_runtime_contract,
+            repair_attempts=plan_result.repair_attempts,
+        )
+        app_flow_plan = plan_result.plan.model_dump(mode="json")
+        runtime_notes.extend(plan_result.generation_notes)
+        runtime_notes.extend(plan_result.repair_history)
+        runtime_notes.append("AppFlowPlan validated before app.py generation.")
         generation_result = _generate_validated_app_source_with_llm(
             input_model=input_model,
             llm_client=llm_client,
             content_filename=content_filename,
             package_context=package_context,
             builder_runtime_contract=builder_runtime_contract,
+            app_flow_plan=plan_result.plan,
         )
         app_source = generation_result.app_source
         runtime_notes.extend(generation_result.generation_notes)
@@ -233,6 +325,27 @@ def run_prototype_builder_agent(
             f"Builder runtime contract satisfied: {builder_runtime_contract.to_summary_string()}."
         )
         runtime_notes.append("app.py는 LLM 생성 결과를 사용했다.")
+    except BuilderPlanRepairFailed as exc:
+        builder_errors.extend(
+            _dedupe_preserve_order(
+                [
+                    LLM_OUTPUT_INVALID,
+                    exc.initial_validation_error_code,
+                    exc.repair_validation_error_code,
+                    FALLBACK_USED,
+                ]
+            )
+        )
+        fallback_used = True
+        fallback_reason = (
+            f"{LLM_OUTPUT_INVALID}: {exc.final_error.code}: {exc.final_error.message}"
+        )
+        generation_mode = "fallback_template"
+        app_source = build_fallback_app_source(input_model)
+        runtime_notes.append("AppFlowPlan 검증이 실패해 fallback template을 사용했다.")
+        plan_repair_attempts = exc.repair_attempts
+        plan_summary = [f"AppFlowPlan failed with {exc.final_error.code}."] + exc.repair_history
+        runtime_notes.extend(exc.repair_history)
     except BuilderRepairFailed as exc:
         builder_errors.extend(
             _dedupe_preserve_order(
@@ -301,10 +414,15 @@ def run_prototype_builder_agent(
         runtime_notes=runtime_notes,
         integration_notes=integration_notes,
         generation_mode=generation_mode,
+        generation_stage=generation_stage,
         fallback_used=fallback_used,
         fallback_reason=fallback_reason,
         generation_inputs_summary=generation_inputs_summary,
         reflection_attempts=reflection_attempts,
+        plan_validation_passed=plan_validation_passed,
+        plan_repair_attempts=plan_repair_attempts,
+        plan_summary=plan_summary,
+        app_flow_plan=app_flow_plan,
         repair_attempted=repair_attempted,
         initial_validation_error_code=initial_validation_error_code,
         repair_validation_error_code=repair_validation_error_code,
@@ -351,6 +469,214 @@ def build_fallback_app_source(input_model: PrototypeBuilderInput) -> str:
     )
 
 
+def _generate_app_flow_plan_with_llm(
+    *,
+    input_model: PrototypeBuilderInput,
+    llm_client: LLMClient,
+    content_filename: str,
+    package_context: dict[str, str],
+    builder_runtime_contract: BuilderRuntimeContract,
+) -> AppFlowPlanOutput:
+    prompt = _build_app_flow_plan_prompt(
+        input_model=input_model,
+        content_filename=content_filename,
+        package_context=package_context,
+        builder_runtime_contract=builder_runtime_contract,
+    )
+    return llm_client.generate_json(
+        prompt=prompt,
+        response_model=AppFlowPlanOutput,
+        system_prompt=(
+            "You are a senior software architect generating one structured AppFlowPlan "
+            "for a Streamlit MVP. Return JSON only."
+        ),
+    )
+
+
+def _generate_validated_app_flow_plan_with_llm(
+    *,
+    input_model: PrototypeBuilderInput,
+    llm_client: LLMClient,
+    content_filename: str,
+    package_context: dict[str, str],
+    builder_runtime_contract: BuilderRuntimeContract,
+) -> ValidatedAppFlowPlanResult:
+    generated_plan = _generate_app_flow_plan_with_llm(
+        input_model=input_model,
+        llm_client=llm_client,
+        content_filename=content_filename,
+        package_context=package_context,
+        builder_runtime_contract=builder_runtime_contract,
+    )
+    try:
+        validated_plan = _validate_generated_app_flow_plan(
+            generated_plan=generated_plan,
+            builder_runtime_contract=builder_runtime_contract,
+        )
+        return ValidatedAppFlowPlanResult(
+            plan=validated_plan,
+            generation_notes=_dedupe_preserve_order(
+                [
+                    *generated_plan.generation_notes,
+                    "AppFlowPlan passed deterministic validation.",
+                ]
+            ),
+        )
+    except InvalidAppFlowPlanError as first_error:
+        return _repair_invalid_app_flow_plan_with_llm(
+            input_model=input_model,
+            llm_client=llm_client,
+            content_filename=content_filename,
+            package_context=package_context,
+            builder_runtime_contract=builder_runtime_contract,
+            invalid_plan=generated_plan,
+            first_error=first_error,
+        )
+
+
+def _repair_invalid_app_flow_plan_with_llm(
+    *,
+    input_model: PrototypeBuilderInput,
+    llm_client: LLMClient,
+    content_filename: str,
+    package_context: dict[str, str],
+    builder_runtime_contract: BuilderRuntimeContract,
+    invalid_plan: AppFlowPlanOutput,
+    first_error: InvalidAppFlowPlanError,
+) -> ValidatedAppFlowPlanResult:
+    repair_history = [
+        _format_plan_repair_history_entry(
+            attempt_number=0,
+            error=first_error,
+            status="FAILED",
+            note="Initial AppFlowPlan failed validation.",
+        )
+    ]
+    if not _is_plan_repair_friendly_error(first_error):
+        raise BuilderPlanRepairFailed(
+            first_error,
+            repair_attempts=0,
+            repair_attempted=False,
+            initial_validation_error_code=first_error.code,
+            repair_validation_error_code="",
+            repair_history=repair_history + ["Plan repair skipped: failure was not repair-friendly."],
+        )
+
+    previous_error = first_error
+    current_invalid_plan = invalid_plan
+    repair_attempts = 0
+    generation_notes = list(invalid_plan.generation_notes)
+
+    for attempt_number in range(1, MAX_PLAN_REPAIR_ATTEMPTS + 1):
+        repair_attempts = attempt_number
+        repair_prompt = _build_app_flow_plan_repair_prompt(
+            input_model=input_model,
+            content_filename=content_filename,
+            invalid_plan=current_invalid_plan,
+            validation_error=previous_error,
+            package_context=package_context,
+            builder_runtime_contract=builder_runtime_contract,
+            repair_attempt_number=attempt_number,
+            max_repair_attempts=MAX_PLAN_REPAIR_ATTEMPTS,
+            repair_history=repair_history,
+        )
+        try:
+            repaired_plan = llm_client.generate_json(
+                prompt=repair_prompt,
+                response_model=AppFlowPlanOutput,
+                system_prompt=(
+                    "You repair one AppFlowPlan so it satisfies the runtime contract. "
+                    "Return JSON only."
+                ),
+            )
+        except Exception as exc:
+            repair_history.append(
+                f"Plan repair attempt {attempt_number} failed before validation: LLM_CALL_FAILED ({exc})."
+            )
+            raise BuilderPlanRepairFailed(
+                InvalidAppFlowPlanError(
+                    LLM_CALL_FAILED,
+                    f"Plan repair attempt {attempt_number} LLM call failed: {exc}.",
+                ),
+                repair_attempts=repair_attempts,
+                repair_attempted=True,
+                initial_validation_error_code=first_error.code,
+                repair_validation_error_code=LLM_CALL_FAILED,
+                repair_history=repair_history,
+            ) from exc
+
+        try:
+            validated_plan = _validate_generated_app_flow_plan(
+                generated_plan=repaired_plan,
+                builder_runtime_contract=builder_runtime_contract,
+            )
+            repair_history.append(
+                f"Plan repair attempt {attempt_number} succeeded after {previous_error.code}."
+            )
+            return ValidatedAppFlowPlanResult(
+                plan=validated_plan,
+                generation_notes=_dedupe_preserve_order(
+                    [
+                        *generation_notes,
+                        f"Initial AppFlowPlan failed validation once with {first_error.code}.",
+                        *repaired_plan.generation_notes,
+                        "AppFlowPlan passed deterministic validation after repair.",
+                    ]
+                ),
+                repair_attempts=repair_attempts,
+                repair_attempted=True,
+                initial_validation_error_code=first_error.code,
+                repair_validation_error_code="",
+                repair_history=repair_history,
+            )
+        except InvalidAppFlowPlanError as repair_error:
+            repair_history.append(
+                _format_plan_repair_history_entry(
+                    attempt_number=attempt_number,
+                    error=repair_error,
+                    status="FAILED",
+                    note=f"Plan repair attempt {attempt_number} failed validation.",
+                )
+            )
+            stop_reason = _plan_repair_stop_reason(previous_error, repair_error)
+            if stop_reason:
+                repair_history.append(
+                    f"Plan repair stopped after attempt {attempt_number}: {stop_reason}"
+                )
+                raise BuilderPlanRepairFailed(
+                    repair_error,
+                    repair_attempts=repair_attempts,
+                    repair_attempted=True,
+                    initial_validation_error_code=first_error.code,
+                    repair_validation_error_code=repair_error.code,
+                    repair_history=repair_history,
+                )
+            if not _is_plan_repair_friendly_error(repair_error):
+                repair_history.append(
+                    f"Plan repair stopped after attempt {attempt_number}: failure was not repair-friendly."
+                )
+                raise BuilderPlanRepairFailed(
+                    repair_error,
+                    repair_attempts=repair_attempts,
+                    repair_attempted=True,
+                    initial_validation_error_code=first_error.code,
+                    repair_validation_error_code=repair_error.code,
+                    repair_history=repair_history,
+                )
+            previous_error = repair_error
+            current_invalid_plan = repaired_plan
+
+    raise BuilderPlanRepairFailed(
+        previous_error,
+        repair_attempts=repair_attempts,
+        repair_attempted=repair_attempts > 0,
+        initial_validation_error_code=first_error.code,
+        repair_validation_error_code=previous_error.code,
+        repair_history=repair_history
+        + [f"Plan repair budget exhausted after {repair_attempts} attempts."],
+    )
+
+
 def _generate_app_source_with_llm(
     *,
     input_model: PrototypeBuilderInput,
@@ -358,12 +684,14 @@ def _generate_app_source_with_llm(
     content_filename: str,
     package_context: dict[str, str],
     builder_runtime_contract: BuilderRuntimeContract,
+    app_flow_plan: AppFlowPlanOutput,
 ) -> AppSourceGenerationOutput:
     prompt = _build_app_generation_prompt(
         input_model=input_model,
         content_filename=content_filename,
         package_context=package_context,
         builder_runtime_contract=builder_runtime_contract,
+        app_flow_plan=app_flow_plan,
     )
     return llm_client.generate_json(
         prompt=prompt,
@@ -382,6 +710,7 @@ def _generate_validated_app_source_with_llm(
     content_filename: str,
     package_context: dict[str, str],
     builder_runtime_contract: BuilderRuntimeContract,
+    app_flow_plan: AppFlowPlanOutput,
 ) -> ValidatedAppSourceResult:
     generated_app = _generate_app_source_with_llm(
         input_model=input_model,
@@ -389,6 +718,7 @@ def _generate_validated_app_source_with_llm(
         content_filename=content_filename,
         package_context=package_context,
         builder_runtime_contract=builder_runtime_contract,
+        app_flow_plan=app_flow_plan,
     )
     try:
         validated_source = _validate_generated_app_source(
@@ -414,6 +744,7 @@ def _generate_validated_app_source_with_llm(
             first_error=first_error,
             generated_app=generated_app,
             builder_runtime_contract=builder_runtime_contract,
+            app_flow_plan=app_flow_plan,
         )
 
 
@@ -426,6 +757,7 @@ def _repair_invalid_app_source_with_llm(
     first_error: InvalidAppSourceError,
     generated_app: AppSourceGenerationOutput,
     builder_runtime_contract: BuilderRuntimeContract,
+    app_flow_plan: AppFlowPlanOutput,
 ) -> ValidatedAppSourceResult:
     repair_history = [
         _format_repair_history_entry(
@@ -458,6 +790,7 @@ def _repair_invalid_app_source_with_llm(
             invalid_source=current_invalid_source,
             validation_error=previous_error,
             builder_runtime_contract=builder_runtime_contract,
+            app_flow_plan=app_flow_plan,
             repair_attempt_number=attempt_number,
             max_repair_attempts=MAX_BUILDER_REPAIR_ATTEMPTS,
             repair_history=repair_history,
@@ -557,12 +890,150 @@ def _repair_invalid_app_source_with_llm(
     )
 
 
+def _build_app_flow_plan_prompt(
+    *,
+    input_model: PrototypeBuilderInput,
+    content_filename: str,
+    package_context: dict[str, str],
+    builder_runtime_contract: BuilderRuntimeContract,
+) -> str:
+    prompt_template = load_prompt_text("prototype_builder_plan.md")
+    expected_content_runtime_source = _expected_content_runtime_source(builder_runtime_contract)
+    context = {
+        "target_framework": input_model.implementation_spec.target_framework,
+        "service_name": input_model.implementation_spec.service_name,
+        "service_purpose": input_model.implementation_spec.service_purpose,
+        "content_filename": content_filename,
+        "interaction_mode": input_model.content_interaction_output.interaction_mode,
+        "interaction_mode_reason": input_model.content_interaction_output.interaction_mode_reason,
+        "expected_content_runtime_source": expected_content_runtime_source,
+        "required_screen_constants": builder_runtime_contract.required_screen_constants,
+        "required_transition_assignments": builder_runtime_contract.required_transition_assignments,
+        "required_functions": builder_runtime_contract.required_functions,
+        "required_runtime_literals": builder_runtime_contract.required_runtime_literals,
+        "forbidden_runtime_literals": builder_runtime_contract.forbidden_runtime_literals,
+        "forbidden_raw_runtime_fields": builder_runtime_contract.forbidden_raw_runtime_fields,
+        "quest_sequence": builder_runtime_contract.quest_sequence,
+        "spec_intake_output": input_model.spec_intake_output.model_dump(mode="json"),
+        "requirement_mapping_output": input_model.requirement_mapping_output.model_dump(mode="json"),
+        "content_interaction_output": input_model.content_interaction_output.model_dump(mode="json"),
+        "interface_spec": package_context.get("interface_spec", ""),
+        "state_machine": package_context.get("state_machine", ""),
+        "data_schema": package_context.get("data_schema", ""),
+        "prompt_spec": package_context.get("prompt_spec", ""),
+        "builder_runtime_contract": builder_runtime_contract.to_prompt_block(),
+    }
+    return prompt_template.format(
+        target_framework=context["target_framework"],
+        service_name=context["service_name"],
+        service_purpose=context["service_purpose"],
+        content_filename=context["content_filename"],
+        interaction_mode=context["interaction_mode"],
+        interaction_mode_reason=context["interaction_mode_reason"],
+        expected_content_runtime_source=context["expected_content_runtime_source"],
+        required_screen_constants=json.dumps(
+            context["required_screen_constants"],
+            ensure_ascii=False,
+        ),
+        required_transition_assignments=json.dumps(
+            context["required_transition_assignments"],
+            ensure_ascii=False,
+        ),
+        required_functions=json.dumps(
+            context["required_functions"],
+            ensure_ascii=False,
+        ),
+        required_runtime_literals=json.dumps(
+            context["required_runtime_literals"],
+            ensure_ascii=False,
+        ),
+        forbidden_runtime_literals=json.dumps(
+            context["forbidden_runtime_literals"],
+            ensure_ascii=False,
+        ),
+        forbidden_raw_runtime_fields=json.dumps(
+            context["forbidden_raw_runtime_fields"],
+            ensure_ascii=False,
+        ),
+        quest_sequence=json.dumps(context["quest_sequence"], ensure_ascii=False),
+        spec_intake_output=json.dumps(
+            context["spec_intake_output"],
+            ensure_ascii=False,
+            indent=2,
+        ),
+        requirement_mapping_output=json.dumps(
+            context["requirement_mapping_output"],
+            ensure_ascii=False,
+            indent=2,
+        ),
+        content_interaction_output=json.dumps(
+            context["content_interaction_output"],
+            ensure_ascii=False,
+            indent=2,
+        ),
+        interface_spec=context["interface_spec"],
+        state_machine=context["state_machine"],
+        data_schema=context["data_schema"],
+        prompt_spec=context["prompt_spec"],
+        builder_runtime_contract=context["builder_runtime_contract"],
+    )
+
+
+def _build_app_flow_plan_repair_prompt(
+    *,
+    input_model: PrototypeBuilderInput,
+    content_filename: str,
+    invalid_plan: AppFlowPlanOutput,
+    validation_error: InvalidAppFlowPlanError,
+    package_context: dict[str, str],
+    builder_runtime_contract: BuilderRuntimeContract,
+    repair_attempt_number: int,
+    max_repair_attempts: int,
+    repair_history: list[str],
+) -> str:
+    failed_items = validation_error.contract_items or [validation_error.message]
+    expected_content_runtime_source = _expected_content_runtime_source(builder_runtime_contract)
+    return (
+        "The previous generated AppFlowPlan failed validation.\n"
+        f"Plan repair attempt: {repair_attempt_number} / {max_repair_attempts}\n"
+        f"Validation error code: {validation_error.code}\n"
+        f"Validation error: {validation_error.message}\n\n"
+        "Repair targets:\n"
+        f"- interaction_mode: {input_model.content_interaction_output.interaction_mode}\n"
+        f"- expected_content_runtime_source: {expected_content_runtime_source}\n"
+        f"- required_screen_constants: {json.dumps(builder_runtime_contract.required_screen_constants, ensure_ascii=False)}\n"
+        f"- required_transition_assignments: {json.dumps(builder_runtime_contract.required_transition_assignments, ensure_ascii=False)}\n"
+        f"- required_functions: {json.dumps(builder_runtime_contract.required_functions, ensure_ascii=False)}\n"
+        f"- required_runtime_literals: {json.dumps(builder_runtime_contract.required_runtime_literals, ensure_ascii=False)}\n"
+        f"- forbidden_runtime_literals: {json.dumps(builder_runtime_contract.forbidden_runtime_literals, ensure_ascii=False)}\n"
+        f"- forbidden_raw_runtime_fields: {json.dumps(builder_runtime_contract.forbidden_raw_runtime_fields, ensure_ascii=False)}\n\n"
+        "Preserve the valid parts of the existing plan and fix only the missing flow contract items.\n"
+        "Do not switch interaction_mode or content_runtime_source unless the validator explicitly says they are wrong.\n"
+        "Keep required screen constants, required functions, and transitions aligned with the builder runtime contract.\n\n"
+        "Builder runtime contract:\n"
+        f"{builder_runtime_contract.to_prompt_block()}\n\n"
+        "Missing or invalid plan items:\n"
+        f"{json.dumps(failed_items, ensure_ascii=False, indent=2)}\n\n"
+        "Plan repair history so far:\n"
+        f"{json.dumps(repair_history, ensure_ascii=False, indent=2)}\n\n"
+        "Reference planning context:\n"
+        f"- content_filename: {content_filename}\n"
+        f"- interaction_mode: {input_model.content_interaction_output.interaction_mode}\n"
+        f"- interface_spec_present: {json.dumps(bool(package_context.get('interface_spec')))}\n"
+        f"- state_machine_present: {json.dumps(bool(package_context.get('state_machine')))}\n"
+        f"- data_schema_present: {json.dumps(bool(package_context.get('data_schema')))}\n\n"
+        "Previous invalid AppFlowPlan JSON:\n"
+        f"{json.dumps(invalid_plan.model_dump(mode='json'), ensure_ascii=False, indent=2)}"
+    )
+
+
 def _build_app_generation_prompt(
     *,
     input_model: PrototypeBuilderInput,
     content_filename: str,
     package_context: dict[str, str],
     builder_runtime_contract: BuilderRuntimeContract,
+    app_flow_plan: AppFlowPlanOutput,
 ) -> str:
     spec = input_model.implementation_spec
     prompt_template = load_prompt_text("prototype_builder.md")
@@ -589,6 +1060,7 @@ def _build_app_generation_prompt(
         "flow_notes": input_model.content_interaction_output.flow_notes,
         "evaluation_rules": input_model.content_interaction_output.evaluation_rules,
         "builder_runtime_contract": builder_runtime_contract.to_prompt_block(),
+        "validated_app_flow_plan": app_flow_plan.model_dump(mode="json"),
     }
     return prompt_template.format(
         target_framework=context["target_framework"],
@@ -622,6 +1094,11 @@ def _build_app_generation_prompt(
             indent=2,
         ),
         builder_runtime_contract=context["builder_runtime_contract"],
+        validated_app_flow_plan=json.dumps(
+            context["validated_app_flow_plan"],
+            ensure_ascii=False,
+            indent=2,
+        ),
     )
 
 
@@ -632,6 +1109,7 @@ def _build_app_validation_repair_prompt(
     invalid_source: str,
     validation_error: InvalidAppSourceError,
     builder_runtime_contract: BuilderRuntimeContract,
+    app_flow_plan: AppFlowPlanOutput,
     repair_attempt_number: int,
     max_repair_attempts: int,
     repair_history: list[str],
@@ -651,6 +1129,8 @@ def _build_app_validation_repair_prompt(
         "If a missing contract item is shown as a literal assignment or literal marker, insert that exact literal.\n\n"
         "Builder runtime contract:\n"
         f"{builder_runtime_contract.to_prompt_block()}\n\n"
+        "Validated AppFlowPlan:\n"
+        f"{json.dumps(app_flow_plan.model_dump(mode='json'), ensure_ascii=False, indent=2)}\n\n"
         "Missing or invalid contract items:\n"
         f"{json.dumps(failed_items, ensure_ascii=False, indent=2)}\n\n"
         "Repair history so far:\n"
@@ -690,6 +1170,39 @@ def _repair_stop_reason(
     return ""
 
 
+def _is_plan_repair_friendly_error(error: InvalidAppFlowPlanError) -> bool:
+    contract_items = error.contract_items or [error.message]
+    return error.code in PLAN_REPAIR_FRIENDLY_CODES and len(contract_items) <= 3
+
+
+def _plan_repair_stop_reason(
+    previous_error: InvalidAppFlowPlanError,
+    current_error: InvalidAppFlowPlanError,
+) -> str:
+    previous_items = previous_error.contract_items or [previous_error.message]
+    current_items = current_error.contract_items or [current_error.message]
+    if current_error.code == previous_error.code:
+        return f"same validation error code repeated ({current_error.code})"
+    if current_items == previous_items:
+        return "plan contract items did not change between repair attempts"
+    return ""
+
+
+def _format_plan_repair_history_entry(
+    *,
+    attempt_number: int,
+    error: InvalidAppFlowPlanError,
+    status: str,
+    note: str,
+) -> str:
+    contract_items = ", ".join(error.contract_items or []) or "none"
+    label = "initial_plan_validation" if attempt_number == 0 else f"plan_repair_attempt_{attempt_number}"
+    return (
+        f"{label}: {status} code={error.code}; "
+        f"contract_items=[{contract_items}]; note={note}"
+    )
+
+
 def _format_repair_history_entry(
     *,
     attempt_number: int,
@@ -703,6 +1216,130 @@ def _format_repair_history_entry(
         f"{label}: {status} code={error.code}; "
         f"contract_items=[{contract_items}]; note={note}"
     )
+
+
+def _validate_generated_app_flow_plan(
+    *,
+    generated_plan: AppFlowPlanOutput,
+    builder_runtime_contract: BuilderRuntimeContract,
+) -> AppFlowPlanOutput:
+    if generated_plan.interaction_mode != builder_runtime_contract.interaction_mode:
+        raise InvalidAppFlowPlanError(
+            PLAN_CONTENT_RUNTIME_SOURCE_INVALID,
+            "AppFlowPlan interaction_mode does not match the Builder runtime contract.",
+            contract_items=[builder_runtime_contract.interaction_mode],
+        )
+    if generated_plan.content_loading_order != "outputs_first":
+        raise InvalidAppFlowPlanError(
+            PLAN_LOADING_ORDER_INVALID,
+            "AppFlowPlan must keep outputs_first content loading order.",
+            contract_items=["content_loading_order=outputs_first"],
+        )
+
+    expected_content_runtime_source = _expected_content_runtime_source(builder_runtime_contract)
+    if generated_plan.content_runtime_source != expected_content_runtime_source:
+        raise InvalidAppFlowPlanError(
+            PLAN_CONTENT_RUNTIME_SOURCE_INVALID,
+            "AppFlowPlan content_runtime_source does not match the expected runtime collection.",
+            contract_items=[expected_content_runtime_source],
+        )
+
+    screen_ids = [screen.screen_id for screen in generated_plan.screens]
+    missing_screens = [
+        screen_id
+        for screen_id in builder_runtime_contract.required_screen_constants
+        if screen_id not in screen_ids
+    ]
+    if missing_screens:
+        raise InvalidAppFlowPlanError(
+            PLAN_SCREENS_MISSING,
+            "AppFlowPlan is missing one or more required screens.",
+            contract_items=missing_screens,
+        )
+
+    transition_assignments = [transition.state_assignment for transition in generated_plan.transitions]
+    missing_transitions = [
+        assignment
+        for assignment in builder_runtime_contract.required_transition_assignments
+        if assignment not in transition_assignments
+    ]
+    if missing_transitions:
+        raise InvalidAppFlowPlanError(
+            PLAN_TRANSITIONS_MISSING,
+            "AppFlowPlan is missing one or more required current_screen transitions.",
+            contract_items=missing_transitions,
+        )
+
+    missing_functions = [
+        function_name
+        for function_name in builder_runtime_contract.required_functions
+        if function_name not in generated_plan.required_functions
+    ]
+    if missing_functions:
+        raise InvalidAppFlowPlanError(
+            PLAN_FUNCTIONS_MISSING,
+            "AppFlowPlan is missing one or more required runtime functions.",
+            contract_items=missing_functions,
+        )
+
+    missing_runtime_literals = [
+        literal
+        for literal in builder_runtime_contract.required_runtime_literals
+        if literal not in generated_plan.required_runtime_literals
+    ]
+    if missing_runtime_literals:
+        raise InvalidAppFlowPlanError(
+            PLAN_RUNTIME_LITERAL_MISSING,
+            "AppFlowPlan is missing one or more required runtime literals.",
+            contract_items=missing_runtime_literals,
+        )
+
+    if builder_runtime_contract.forbidden_runtime_literals:
+        missing_forbidden_literals = [
+            literal
+            for literal in builder_runtime_contract.forbidden_runtime_literals
+            if literal not in generated_plan.forbidden_runtime_literals
+        ]
+        if missing_forbidden_literals:
+            raise InvalidAppFlowPlanError(
+                PLAN_RUNTIME_LITERAL_MISSING,
+                "AppFlowPlan must explicitly forbid legacy runtime literals for this service family.",
+                contract_items=missing_forbidden_literals,
+            )
+
+    if builder_runtime_contract.interaction_mode == "coaching":
+        if (
+            generated_plan.error_path is None
+            or generated_plan.error_path.target_screen != "SCREEN_ERROR"
+            or generated_plan.error_path.state_assignment
+            != "st.session_state.current_screen = SCREEN_ERROR"
+        ):
+            raise InvalidAppFlowPlanError(
+                PLAN_ERROR_PATH_MISSING,
+                "Coaching AppFlowPlan must define an explicit SCREEN_ERROR path.",
+                contract_items=["st.session_state.current_screen = SCREEN_ERROR"],
+            )
+        if (
+            generated_plan.result_path is None
+            or generated_plan.result_path.target_screen != "SCREEN_RESULT"
+        ):
+            raise InvalidAppFlowPlanError(
+                PLAN_RESULT_PATH_MISSING,
+                "Coaching AppFlowPlan must define an explicit SCREEN_RESULT path.",
+                contract_items=["SCREEN_RESULT"],
+            )
+    elif builder_runtime_contract.requires_session_result:
+        if (
+            generated_plan.result_path is None
+            or generated_plan.result_path.target_screen != "SCREEN_SESSION_RESULT"
+        ):
+            raise InvalidAppFlowPlanError(
+                PLAN_RESULT_PATH_MISSING,
+                "Quiz AppFlowPlan must define an explicit SCREEN_SESSION_RESULT path.",
+                contract_items=["SCREEN_SESSION_RESULT"],
+            )
+
+    return generated_plan
 
 
 def _validate_generated_app_source(
@@ -754,6 +1391,18 @@ def _validate_generated_app_source(
             INVALID_STREAMLIT_API,
             "app_source must use st.rerun() instead of st.experimental_rerun().",
             contract_items=["st.rerun()"],
+        )
+    if "st.experimental_get_query_params" in app_source:
+        raise InvalidAppSourceError(
+            INVALID_STREAMLIT_API,
+            "app_source must use st.query_params instead of st.experimental_get_query_params().",
+            contract_items=["st.query_params"],
+        )
+    if "st.experimental_set_query_params" in app_source:
+        raise InvalidAppSourceError(
+            INVALID_STREAMLIT_API,
+            "app_source must use st.query_params instead of st.experimental_set_query_params().",
+            contract_items=["st.query_params"],
         )
     try:
         compile(app_source, "app.py", "exec")
@@ -1024,6 +1673,7 @@ def _build_generation_inputs_summary(
 ) -> list[str]:
     spec = input_model.implementation_spec
     summary = [
+        "generation_stage=plan_then_code",
         f"target_framework={spec.target_framework}",
         f"service_purpose={'present' if spec.service_purpose else 'missing'}",
         f"target_user_count={len(spec.target_users)}",
@@ -1037,10 +1687,37 @@ def _build_generation_inputs_summary(
         "requirement_mapping_output",
         "content_interaction_output",
         "builder_runtime_contract",
+        "app_flow_plan",
     ]
     if _is_planning_package_dir(Path(spec.source_path)):
         summary.extend(["interface_spec", "state_machine", "data_schema", "prompt_spec"])
     return summary
+
+
+def _expected_content_runtime_source(builder_runtime_contract: BuilderRuntimeContract) -> str:
+    if any("interaction_units" in literal for literal in builder_runtime_contract.required_runtime_literals):
+        return "interaction_units"
+    return "quests"
+
+
+def _build_plan_summary(
+    app_flow_plan: AppFlowPlanOutput,
+    *,
+    builder_runtime_contract: BuilderRuntimeContract,
+    repair_attempts: int,
+) -> list[str]:
+    return [
+        f"interaction_mode={app_flow_plan.interaction_mode}",
+        f"content_runtime_source={app_flow_plan.content_runtime_source}",
+        f"screen_count={len(app_flow_plan.screens)}",
+        f"transition_count={len(app_flow_plan.transitions)}",
+        f"required_function_count={len(app_flow_plan.required_functions)}",
+        f"plan_repair_attempts={repair_attempts}",
+        (
+            "required_screens="
+            + ",".join(builder_runtime_contract.required_screen_constants)
+        ),
+    ]
 
 
 def _mandatory_content_loading_contract(content_filename: str) -> str:
@@ -1256,6 +1933,13 @@ def _build_repair_guidance(
         )
     if validation_error.code == PYTHON_SYNTAX_INVALID:
         guidance.append("Fix Python syntax first, then preserve all required screen constants and transitions.")
+    if validation_error.code == INVALID_STREAMLIT_API:
+        guidance.extend(
+            [
+                "Use st.rerun() instead of st.experimental_rerun().",
+                "Use st.query_params instead of st.experimental_get_query_params() or st.experimental_set_query_params().",
+            ]
+        )
     return json.dumps(guidance, ensure_ascii=False, indent=2)
 
 

--- a/orchestrator/pipeline.py
+++ b/orchestrator/pipeline.py
@@ -427,6 +427,11 @@ class ImplementationPipeline:
             self.output_dir / "prototype_builder_output.json",
             prototype_builder_output,
         )
+        if prototype_builder_output.app_flow_plan:
+            self._save_json_data(
+                self.output_dir / "builder_flow_plan.json",
+                prototype_builder_output.app_flow_plan,
+            )
         if not prototype_builder_output.is_supported:
             return prototype_builder_output, None
 

--- a/prompts/implementation/prototype_builder.md
+++ b/prompts/implementation/prototype_builder.md
@@ -52,6 +52,9 @@ prompt_spec:
 builder_runtime_contract:
 {builder_runtime_contract}
 
+validated_app_flow_plan:
+{validated_app_flow_plan}
+
 반드시 아래를 지켜라:
 - `target_framework == "streamlit"`일 때만 app.py를 생성한다.
 - app은 `outputs/{content_filename}`을 우선 읽고, 루트 `{content_filename}`을 fallback으로 읽어야 한다.
@@ -64,6 +67,8 @@ builder_runtime_contract:
 - 금지: `CONTENT_PATH = "{content_filename}"`를 먼저 검사한 뒤 `outputs/{content_filename}`를 fallback으로 읽는 root-first 로딩 구조.
 - app.py 실행 시 planning package 파일(interface_spec.md, state_machine.md, data_schema.json, prompt_spec.md, constitution.md)을 다시 읽으면 안 된다.
 - `interaction_units`는 화면 흐름 생성을 위한 primary contract다.
+- `validated_app_flow_plan`은 이미 검증을 통과한 intermediate plan이다. app.py는 이 plan을 다시 해석하거나 변경하지 말고 그대로 materialize해야 한다.
+- `validated_app_flow_plan.screens`, `validated_app_flow_plan.transitions`, `validated_app_flow_plan.required_functions`, `validated_app_flow_plan.content_runtime_source`를 소스에 직접 반영하라.
 - 화면 흐름은 `interaction_units`의 순서, `interaction_type`, `next_step`, `metadata`를 기준으로 구성한다.
 - `interaction_mode`는 secondary hint only다. quiz/coaching 전용 deterministic template을 새로 만들지 말고, `interaction_units` 계약을 우선 해석하라.
 - `items`가 비어 있고 `interaction_units`가 존재하면, 런타임 콘텐츠 컬렉션은 반드시 `interaction_units`여야 한다. 이 경우 `content.get("quests")` 또는 `data.get("quests")` 같은 legacy quiz 접근은 금지다.
@@ -79,6 +84,7 @@ builder_runtime_contract:
 - `streamlit` 앱에서 사용자는 문제 풀이, 정답 확인, 해설과 학습 포인트 확인이 가능해야 한다.
 - planning package 입력이면 interface_spec, state_machine, data_schema의 score/grade 규칙, prompt_spec의 평가 의도를 반영한다.
 - Streamlit 재실행 API는 `st.rerun()`만 사용한다. `st.experimental_rerun()`은 사용하지 않는다.
+- query parameter 접근은 `st.query_params`만 사용한다. `st.experimental_get_query_params()`와 `st.experimental_set_query_params()`는 사용하지 않는다.
 - `current_screen` 기반 상태 머신을 구현하고, `SCREEN_START`, `SCREEN_MULTIPLE_CHOICE`, `SCREEN_MULTIPLE_CHOICE_RESULT`, `SCREEN_IMPROVEMENT`, `SCREEN_IMPROVEMENT_RESULT`, `SCREEN_BATTLE`, `SCREEN_BATTLE_RESULT`, `SCREEN_BATTLE_COMPLETED`, `SCREEN_SESSION_RESULT`를 필요한 만큼 포함하라.
 - 제출 직후 바로 다음 문제로 이동하지 말고, 반드시 `SCREEN_MULTIPLE_CHOICE_RESULT`, `SCREEN_IMPROVEMENT_RESULT`, 또는 `SCREEN_BATTLE_RESULT` feedback screen을 거쳐라.
 - `퀘스트 v2` 입력에서는 `multiple_choice → situation_card → question_improvement → situation_card → battle` 흐름을 반영해야 한다.

--- a/prompts/implementation/prototype_builder_plan.md
+++ b/prompts/implementation/prototype_builder_plan.md
@@ -1,0 +1,83 @@
+당신은 Prototype Builder Agent의 설계 단계다.
+
+목표:
+- 전체 `app.py`를 바로 생성하지 말고, 먼저 검증 가능한 `AppFlowPlan` JSON만 생성한다.
+- 이 plan은 이후 code generation 단계에서 그대로 materialize된다.
+- 외부 LLM API를 app runtime에서 호출하는 구조를 계획에 넣으면 안 된다.
+
+실행 설정:
+- target_framework: {target_framework}
+- service_name: {service_name}
+- service_purpose: {service_purpose}
+- content_filename: {content_filename}
+- interaction_mode: {interaction_mode}
+- interaction_mode_reason: {interaction_mode_reason}
+- expected_content_runtime_source: {expected_content_runtime_source}
+- required_screen_constants: {required_screen_constants}
+- required_transition_assignments: {required_transition_assignments}
+- required_functions: {required_functions}
+- required_runtime_literals: {required_runtime_literals}
+- forbidden_runtime_literals: {forbidden_runtime_literals}
+- forbidden_raw_runtime_fields: {forbidden_raw_runtime_fields}
+- quest_sequence: {quest_sequence}
+
+명세 요약:
+{spec_intake_output}
+
+구현 계약:
+{requirement_mapping_output}
+
+콘텐츠 데이터:
+{content_interaction_output}
+
+interface_spec:
+{interface_spec}
+
+state_machine:
+{state_machine}
+
+data_schema:
+{data_schema}
+
+prompt_spec:
+{prompt_spec}
+
+builder_runtime_contract:
+{builder_runtime_contract}
+
+반드시 아래를 지켜라:
+- `content_runtime_source`는 반드시 `{expected_content_runtime_source}` 여야 한다.
+- `content_loading_order`는 반드시 `outputs_first` 여야 한다.
+- `screens`에는 위 `required_screen_constants`가 모두 포함되어야 한다.
+- `transitions`에는 위 `required_transition_assignments`가 모두 `state_assignment`로 포함되어야 한다.
+- `required_functions`에는 위 `required_functions`가 모두 포함되어야 한다.
+- `required_runtime_literals`와 `forbidden_runtime_literals`를 plan에 그대로 담아라.
+- coaching flow라면 `error_path`는 `SCREEN_ERROR`로, result path는 `SCREEN_RESULT`로 정의하라.
+- quiz flow라면 `result_path`는 `SCREEN_SESSION_RESULT`로 끝나게 정의하라.
+- raw runtime field(`item_id`, `choices`)는 source에서 직접 읽지 않도록 `forbidden_raw_runtime_fields`에 유지하라.
+- 아직 Python source를 쓰지 말고, 오직 structured plan만 작성하라.
+
+반환 형식:
+- `interaction_mode`
+- `content_runtime_source`
+- `content_loading_order`
+- `screens`
+  - `screen_id`
+  - `purpose`
+  - `interaction_type`
+  - `required_ui_elements`
+- `transitions`
+  - `from_screen`
+  - `to_screen`
+  - `trigger`
+  - `state_assignment`
+- `required_functions`
+- `required_runtime_literals`
+- `forbidden_runtime_literals`
+- `forbidden_raw_runtime_fields`
+- `data_bindings`
+- `error_path`
+- `result_path`
+- `generation_notes`
+
+JSON only.

--- a/schemas/implementation/prototype_builder.py
+++ b/schemas/implementation/prototype_builder.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from typing import Any
+
 from pydantic import Field
 
 from schemas.implementation.common import AgentLabel, GeneratedFile, SchemaModel
@@ -36,6 +38,89 @@ class AppSourceGenerationOutput(SchemaModel):
     )
 
 
+class AppFlowScreen(SchemaModel):
+    screen_id: str = Field(description="Literal screen constant such as SCREEN_START.")
+    purpose: str = Field(default="", description="What this screen is responsible for.")
+    interaction_type: str = Field(
+        default="",
+        description="Interaction type handled on this screen, if any.",
+    )
+    required_ui_elements: list[str] = Field(
+        default_factory=list,
+        description="UI elements or literals that should appear on this screen.",
+    )
+
+
+class AppFlowTransition(SchemaModel):
+    from_screen: str = Field(description="Starting screen constant.")
+    to_screen: str = Field(description="Target screen constant.")
+    trigger: str = Field(default="", description="Event that triggers the transition.")
+    state_assignment: str = Field(
+        description="Literal current_screen assignment required in app.py.",
+    )
+
+
+class AppFlowPath(SchemaModel):
+    target_screen: str = Field(description="Destination screen constant.")
+    trigger: str = Field(default="", description="Condition or trigger for entering this path.")
+    state_assignment: str = Field(
+        default="",
+        description="Literal state assignment that must appear in source.",
+    )
+    notes: str = Field(default="", description="Short explanation of the path.")
+
+
+class AppFlowPlanOutput(SchemaModel):
+    interaction_mode: str = Field(description="Interaction mode the app flow implements.")
+    content_runtime_source: str = Field(
+        description="Primary runtime collection such as quests or interaction_units."
+    )
+    content_loading_order: str = Field(
+        default="outputs_first",
+        description="How app.py loads content files. Must remain outputs_first.",
+    )
+    screens: list[AppFlowScreen] = Field(
+        default_factory=list,
+        description="Screen-level plan for the generated app.",
+    )
+    transitions: list[AppFlowTransition] = Field(
+        default_factory=list,
+        description="Explicit current_screen transitions required by the runtime contract.",
+    )
+    required_functions: list[str] = Field(
+        default_factory=list,
+        description="Function names that must appear in the generated app.",
+    )
+    required_runtime_literals: list[str] = Field(
+        default_factory=list,
+        description="Runtime literals that should appear in generated source.",
+    )
+    forbidden_runtime_literals: list[str] = Field(
+        default_factory=list,
+        description="Legacy runtime access literals that must not appear in source.",
+    )
+    forbidden_raw_runtime_fields: list[str] = Field(
+        default_factory=list,
+        description="Raw quest field literals that must not appear outside normalization helpers.",
+    )
+    data_bindings: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Runtime binding summary, including collection names and field mappings.",
+    )
+    error_path: AppFlowPath | None = Field(
+        default=None,
+        description="Error-handling path that should be reachable in the app flow.",
+    )
+    result_path: AppFlowPath | None = Field(
+        default=None,
+        description="Primary result/completion path that should be reachable in the app flow.",
+    )
+    generation_notes: list[str] = Field(
+        default_factory=list,
+        description="Notes explaining how the plan interprets the service contract.",
+    )
+
+
 class PrototypeBuilderOutput(SchemaModel):
     agent: AgentLabel | None = Field(default=None, description="Agent label metadata.")
     service_name: str = Field(description="Service name for the generated MVP.")
@@ -68,6 +153,10 @@ class PrototypeBuilderOutput(SchemaModel):
         default="llm_generated",
         description="How app.py was produced: llm_generated, fallback_template, or unsupported.",
     )
+    generation_stage: str = Field(
+        default="direct_code",
+        description="Builder generation strategy, for example direct_code or plan_then_code.",
+    )
     fallback_used: bool = Field(
         default=False,
         description="Whether the deterministic fallback template was used.",
@@ -83,6 +172,22 @@ class PrototypeBuilderOutput(SchemaModel):
     reflection_attempts: int = Field(
         default=0,
         description="Number of Builder repair attempts and downstream patch/reflection attempts.",
+    )
+    plan_validation_passed: bool = Field(
+        default=False,
+        description="Whether the intermediate AppFlowPlan passed validation before code generation.",
+    )
+    plan_repair_attempts: int = Field(
+        default=0,
+        description="Number of plan repair attempts performed before code generation.",
+    )
+    plan_summary: list[str] = Field(
+        default_factory=list,
+        description="Short summary of the validated AppFlowPlan and its contract coverage.",
+    )
+    app_flow_plan: dict[str, Any] = Field(
+        default_factory=dict,
+        description="Serialized intermediate AppFlowPlan used for plan-then-code generation.",
     )
     repair_attempted: bool = Field(
         default=False,

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -7,7 +7,7 @@ from orchestrator.app_source import build_streamlit_app_source
 from schemas.implementation.content_interaction import ContentInteractionOutput
 from schemas.implementation.common import QuizItem
 from schemas.implementation.orchestration_decision import OrchestrationJudgeOutput
-from schemas.implementation.prototype_builder import AppSourceGenerationOutput
+from schemas.implementation.prototype_builder import AppFlowPlanOutput, AppSourceGenerationOutput
 from schemas.implementation.prototype_builder import PrototypeBuilderOutput
 from schemas.implementation.qa_alignment import QAAlignmentOutput
 from schemas.implementation.requirement_mapping import RequirementMappingOutput
@@ -34,6 +34,7 @@ class FakeLLMClient:
         invalid_app_generation: bool = False,
         patch_source: str | None = None,
         repair_sources: list[str] | None = None,
+        plan_outputs: list[dict[str, object]] | None = None,
         no_patch: bool = False,
         weak_spec_first_pass: bool = False,
         weak_requirement_first_pass: bool = False,
@@ -47,6 +48,7 @@ class FakeLLMClient:
         self.invalid_app_generation = invalid_app_generation
         self.patch_source = patch_source
         self.repair_sources = list(repair_sources or [])
+        self.plan_outputs = list(plan_outputs or [])
         self.no_patch = no_patch
         self.weak_spec_first_pass = weak_spec_first_pass
         self.weak_requirement_first_pass = weak_requirement_first_pass
@@ -362,6 +364,11 @@ class FakeLLMClient:
                     "ai_question": _build_ai_question_for_type(quiz_type),
                 }
             )
+
+        if response_name == AppFlowPlanOutput.__name__:
+            if self.plan_outputs:
+                return response_model.model_validate(self.plan_outputs.pop(0))
+            return response_model.model_validate(_build_fake_app_flow_plan_from_prompt(prompt))
 
         if response_name == AppSourceGenerationOutput.__name__:
             if self.fail_app_generation:
@@ -1142,14 +1149,18 @@ def _build_evaluation_rules_for_content_types(
 
 
 def _extract_list_from_prompt(prompt: str, field_name: str) -> list[str]:
-    match = re.search(rf"- {re.escape(field_name)}: (\[.*?\])", prompt)
-    if not match:
-        return []
-    try:
-        payload = json.loads(match.group(1))
-    except json.JSONDecodeError:
-        return []
-    return [str(item) for item in payload if str(item).strip()]
+    prefix = f"- {field_name}: "
+    for line in prompt.splitlines():
+        stripped = line.strip()
+        if not stripped.startswith(prefix):
+            continue
+        payload_text = stripped[len(prefix) :].strip()
+        try:
+            payload = json.loads(payload_text)
+        except json.JSONDecodeError:
+            return []
+        return [str(item) for item in payload if str(item).strip()]
+    return []
 
 
 def _extract_int_from_prompt(prompt: str, field_name: str, *, default: int) -> int:
@@ -1164,6 +1175,98 @@ def _extract_scalar_from_prompt(prompt: str, field_name: str) -> str:
     if not match:
         return ""
     return match.group(1).strip()
+
+
+def _build_fake_app_flow_plan_from_prompt(prompt: str) -> dict[str, object]:
+    interaction_mode = _extract_scalar_from_prompt(prompt, "interaction_mode") or "quiz"
+    content_runtime_source = (
+        _extract_scalar_from_prompt(prompt, "expected_content_runtime_source") or "quests"
+    )
+    required_screen_constants = _extract_list_from_prompt(prompt, "required_screen_constants")
+    required_transition_assignments = _extract_list_from_prompt(
+        prompt,
+        "required_transition_assignments",
+    )
+    required_functions = _extract_list_from_prompt(prompt, "required_functions")
+    required_runtime_literals = _extract_list_from_prompt(prompt, "required_runtime_literals")
+    forbidden_runtime_literals = _extract_list_from_prompt(prompt, "forbidden_runtime_literals")
+    forbidden_raw_runtime_fields = _extract_list_from_prompt(prompt, "forbidden_raw_runtime_fields")
+
+    screens = [
+        {
+            "screen_id": screen_id,
+            "purpose": f"{screen_id} runtime screen",
+            "interaction_type": "coaching_feedback" if "FOLLOW_UP" in screen_id else "feedback" if "RESULT" in screen_id else "free_text_input" if screen_id == "SCREEN_INPUT" else "multiple_choice" if "MULTIPLE_CHOICE" in screen_id else "display_content",
+            "required_ui_elements": [screen_id],
+        }
+        for screen_id in required_screen_constants
+    ]
+    transitions = []
+    previous_screen = required_screen_constants[0] if required_screen_constants else "SCREEN_START"
+    for assignment in required_transition_assignments:
+        target_match = re.search(r"=\s*(SCREEN_[A-Z_]+)", assignment)
+        to_screen = target_match.group(1) if target_match else previous_screen
+        transitions.append(
+            {
+                "from_screen": previous_screen,
+                "to_screen": to_screen,
+                "trigger": "state transition",
+                "state_assignment": assignment,
+            }
+        )
+        previous_screen = to_screen
+
+    error_path = None
+    if "SCREEN_ERROR" in required_screen_constants:
+        error_path = {
+            "target_screen": "SCREEN_ERROR",
+            "trigger": "invalid input or exception",
+            "state_assignment": "st.session_state.current_screen = SCREEN_ERROR",
+            "notes": "explicit error path",
+        }
+
+    result_target = (
+        "SCREEN_RESULT"
+        if "SCREEN_RESULT" in required_screen_constants
+        else "SCREEN_SESSION_RESULT"
+        if "SCREEN_SESSION_RESULT" in required_screen_constants
+        else next((screen for screen in required_screen_constants if "RESULT" in screen), "")
+    )
+    result_path = None
+    if result_target:
+        result_path = {
+            "target_screen": result_target,
+            "trigger": "submit completed",
+            "state_assignment": next(
+                (
+                    assignment
+                    for assignment in required_transition_assignments
+                    if result_target in assignment
+                ),
+                "",
+            ),
+            "notes": "primary result path",
+        }
+
+    return {
+        "interaction_mode": interaction_mode,
+        "content_runtime_source": content_runtime_source,
+        "content_loading_order": "outputs_first",
+        "screens": screens,
+        "transitions": transitions,
+        "required_functions": required_functions,
+        "required_runtime_literals": required_runtime_literals,
+        "forbidden_runtime_literals": forbidden_runtime_literals,
+        "forbidden_raw_runtime_fields": forbidden_raw_runtime_fields,
+        "data_bindings": {
+            "runtime_collection": content_runtime_source,
+            "forbidden_runtime_literals": forbidden_runtime_literals,
+            "forbidden_raw_runtime_fields": forbidden_raw_runtime_fields,
+        },
+        "error_path": error_path,
+        "result_path": result_path,
+        "generation_notes": ["fake deterministic AppFlowPlan"],
+    }
 
 
 def _build_llm_generated_streamlit_source(content_filename: str) -> str:

--- a/tests/test_prototype_builder_agent.py
+++ b/tests/test_prototype_builder_agent.py
@@ -47,6 +47,72 @@ def _extract_function_block(source: str, name: str, next_name: str) -> str:
     return source.split(f"def {name}", 1)[1].split(f"def {next_name}", 1)[0]
 
 
+def _build_plan_from_contract(contract, *, runtime_source: str) -> dict[str, object]:
+    screens = [
+        {
+            "screen_id": screen_id,
+            "purpose": f"{screen_id} runtime screen",
+            "interaction_type": "display_content",
+            "required_ui_elements": [screen_id],
+        }
+        for screen_id in contract.required_screen_constants
+    ]
+    transitions = []
+    previous_screen = contract.required_screen_constants[0]
+    for assignment in contract.required_transition_assignments:
+        to_screen = assignment.rsplit("=", 1)[-1].strip()
+        transitions.append(
+            {
+                "from_screen": previous_screen,
+                "to_screen": to_screen,
+                "trigger": "state transition",
+                "state_assignment": assignment,
+            }
+        )
+        previous_screen = to_screen
+
+    error_path = None
+    if "SCREEN_ERROR" in contract.required_screen_constants:
+        error_path = {
+            "target_screen": "SCREEN_ERROR",
+            "trigger": "error",
+            "state_assignment": "st.session_state.current_screen = SCREEN_ERROR",
+            "notes": "error path",
+        }
+    result_target = (
+        "SCREEN_RESULT"
+        if "SCREEN_RESULT" in contract.required_screen_constants
+        else "SCREEN_SESSION_RESULT"
+    )
+    return {
+        "interaction_mode": contract.interaction_mode,
+        "content_runtime_source": runtime_source,
+        "content_loading_order": "outputs_first",
+        "screens": screens,
+        "transitions": transitions,
+        "required_functions": list(contract.required_functions),
+        "required_runtime_literals": list(contract.required_runtime_literals),
+        "forbidden_runtime_literals": list(contract.forbidden_runtime_literals),
+        "forbidden_raw_runtime_fields": list(contract.forbidden_raw_runtime_fields),
+        "data_bindings": {"runtime_collection": runtime_source},
+        "error_path": error_path,
+        "result_path": {
+            "target_screen": result_target,
+            "trigger": "completed",
+            "state_assignment": next(
+                (
+                    assignment
+                    for assignment in contract.required_transition_assignments
+                    if result_target in assignment
+                ),
+                "",
+            ),
+            "notes": "result path",
+        },
+        "generation_notes": ["test flow plan"],
+    }
+
+
 def _build_chatbot_builder_input(fake: FakeLLMClient) -> PrototypeBuilderInput:
     intake_result = load_input_intake(CHATBOT_PACKAGE_DIR)
     assert intake_result.implementation_spec is not None
@@ -99,7 +165,12 @@ def test_prototype_builder_materializes_llm_generated_app_from_planning_package(
     assert output.is_supported is True
     assert output.unsupported_reason == ""
     assert output.generation_mode == "llm_generated"
+    assert output.generation_stage == "plan_then_code"
+    assert output.plan_validation_passed is True
+    assert output.plan_repair_attempts == 0
     assert output.fallback_used is False
+    assert output.app_flow_plan["content_runtime_source"] == "quests"
+    assert any(entry.startswith("screen_count=") for entry in output.plan_summary)
     assert "LLM_GENERATED_APP_MARKER" in source
     assert "def api_session_start()" in source
     assert "def api_quest_submit(user_response: Any)" in source
@@ -136,6 +207,7 @@ def test_prototype_builder_materializes_llm_generated_app_from_planning_package(
     assert "current_screen" in prompt
     assert "st.rerun()" in prompt
     assert "interaction_units(primary contract)" in prompt
+    assert "validated_app_flow_plan" in prompt
     assert '"interaction_mode": "quiz"' in prompt or "interaction_mode:\nquiz" in prompt
     assert "primary contract" in prompt
 
@@ -174,6 +246,7 @@ def test_prototype_builder_materializes_llm_generated_v2_app_without_fallback() 
     prompt = fake.prompts[-1]
 
     assert output.generation_mode == "llm_generated"
+    assert output.plan_validation_passed is True
     assert output.fallback_used is False
     assert "LLM_GENERATED_APP_MARKER" in source
     assert "current_screen" in source
@@ -225,6 +298,8 @@ def test_prototype_builder_materializes_llm_generated_coaching_app_without_legac
     source = output.generated_files[0].content
 
     assert output.generation_mode == "llm_generated"
+    assert output.plan_validation_passed is True
+    assert output.app_flow_plan["content_runtime_source"] == "interaction_units"
     assert output.fallback_used is False
     assert 'get("interaction_units"' in source
     assert 'get("quests"' not in source
@@ -312,6 +387,37 @@ def test_prototype_builder_repairs_single_missing_marker_without_fallback() -> N
     assert any("Repair attempt 1 succeeded" in entry for entry in output.repair_history)
 
 
+def test_prototype_builder_repairs_invalid_plan_before_code_generation() -> None:
+    fake = FakeLLMClient()
+    builder_input = _build_chatbot_builder_input(fake)
+    spec = builder_input.implementation_spec
+    content_filename = build_content_filename(spec.service_name)
+    contract = _build_builder_runtime_contract(
+        input_model=builder_input,
+        content_filename=content_filename,
+        package_context={},
+    )
+    invalid_plan = _build_plan_from_contract(contract, runtime_source="interaction_units")
+    invalid_plan["screens"] = [
+        screen
+        for screen in invalid_plan["screens"]
+        if screen["screen_id"] != "SCREEN_ERROR"
+    ]
+    valid_plan = _build_plan_from_contract(contract, runtime_source="interaction_units")
+    repair_fake = FakeLLMClient(plan_outputs=[invalid_plan, valid_plan])
+
+    output = run_prototype_builder_agent(builder_input, repair_fake)
+
+    assert output.generation_mode == "llm_generated"
+    assert output.plan_validation_passed is True
+    assert output.plan_repair_attempts == 1
+    assert output.fallback_used is False
+    assert "SCREEN_ERROR" in {
+        screen["screen_id"]
+        for screen in output.app_flow_plan["screens"]
+    }
+
+
 def test_prototype_builder_stops_early_when_same_error_repeats() -> None:
     fake = FakeLLMClient()
     builder_input = _build_chatbot_builder_input(fake)
@@ -377,6 +483,60 @@ def test_prototype_builder_allows_second_repair_when_failure_changes() -> None:
     assert output.initial_validation_error_code == "ROOT_FIRST_CONTENT_LOADING"
     assert len(output.repair_history) >= 3
     assert any("Repair attempt 2 succeeded" in entry for entry in output.repair_history)
+
+
+def test_prototype_builder_allows_second_repair_after_syntax_failure() -> None:
+    fake = FakeLLMClient()
+    builder_input = _build_chatbot_builder_input(fake)
+    spec = builder_input.implementation_spec
+    content_filename = build_content_filename(spec.service_name)
+    valid_source = build_streamlit_app_source(
+        spec.service_name,
+        content_filename,
+        interaction_mode="coaching",
+    )
+    invalid_streamlit_source = valid_source.replace("st.rerun()", "st.experimental_rerun()", 1)
+    syntax_invalid_source = valid_source.replace(
+        '    st.write(f"진단 모드: {result.get(\'diagnosis_mode\', \'completed\')}")',
+        '    st.write(f"진단 모드: {result.get(\'diagnosis_mode\', \'completed\')")',
+        1,
+    )
+    repair_fake = FakeLLMClient(
+        app_source=invalid_streamlit_source,
+        repair_sources=[syntax_invalid_source, valid_source],
+    )
+
+    output = run_prototype_builder_agent(builder_input, repair_fake)
+
+    assert output.generation_mode == "llm_generated"
+    assert output.fallback_used is False
+    assert output.reflection_attempts == 2
+    assert output.initial_validation_error_code == "INVALID_STREAMLIT_API"
+    assert any("Repair attempt 2 succeeded" in entry for entry in output.repair_history)
+
+
+def test_prototype_builder_rejects_experimental_query_params_api() -> None:
+    fake = FakeLLMClient()
+    builder_input = _build_chatbot_builder_input(fake)
+    spec = builder_input.implementation_spec
+    content_filename = build_content_filename(spec.service_name)
+    valid_source = build_streamlit_app_source(
+        spec.service_name,
+        content_filename,
+        interaction_mode="coaching",
+    )
+    invalid_source = valid_source.replace(
+        "def contains_any(text: str, markers: list[str]) -> bool:",
+        'st.session_state["session_id"] = st.experimental_get_query_params().get("session_id", ["default"])[0]\n\ndef contains_any(text: str, markers: list[str]) -> bool:',
+        1,
+    )
+    repair_fake = FakeLLMClient(app_source=invalid_source, patch_source=valid_source)
+
+    output = run_prototype_builder_agent(builder_input, repair_fake)
+
+    assert output.generation_mode == "llm_generated"
+    assert output.fallback_used is False
+    assert output.initial_validation_error_code == "INVALID_STREAMLIT_API"
 
 
 def test_prototype_builder_uses_fallback_when_llm_call_fails() -> None:


### PR DESCRIPTION
## Summary
- closes #49
- Prototype Builder를 full-source 단일 생성에서 `AppFlowPlan -> app.py` 2단계 생성으로 전환합니다.
- intermediate `builder_flow_plan.json`을 남기고, plan validator를 먼저 통과한 뒤에만 code generation을 수행합니다.
- code validator/repair는 유지하되, 구조 누락형 오류를 plan 단계에서 먼저 줄이도록 정리했습니다.

## Key Changes
- `AppFlowPlanOutput` intermediate schema 추가
- Builder에 `plan -> code` generation stage 추가
- plan validator / plan repair 추가
- `PrototypeBuilderOutput`에 `generation_stage`, `plan_validation_passed`, `plan_repair_attempts`, `plan_summary`, `app_flow_plan` 추가
- pipeline에서 `builder_flow_plan.json` 저장
- Builder prompt를 validated plan materialization 중심으로 보강
- `st.experimental_get_query_params()` / `st.experimental_set_query_params()`를 `INVALID_STREAMLIT_API`로 금지
- `PYTHON_SYNTAX_INVALID`를 repair-friendly path에 포함

## Verification
- `python -m pytest -q tests/test_prototype_builder_agent.py`
- `python -m pytest -q tests/test_orchestrator.py tests/test_content_interaction_semantics.py`
- `python -m pytest -q`
- live full run recheck
  - `inputs/260428_챗봇/` -> `generation_mode=llm_generated`, `fallback_used=false`, `PASS`
  - `inputs/260429_퀘스트_v2/` -> `generation_mode=llm_generated`, `fallback_used=false`, `PASS`

## Notes
- `/tmp/synnex_issue49/outputs/*` 산출물은 이번 PR에 포함하지 않았습니다.
- 현재 로컬에서 본 챗봇 app runtime issue(`experimental_get_query_params`)는 prompt/validator 레벨에서도 다시 생성되지 않도록 막았습니다.
